### PR TITLE
Add histogram precision note to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,6 +26,12 @@ the JLBH.eventLoopHandler method rather than JLBH.start.
 
 JLBH supports single-thread usage only.
 
+Histogramming of recorded latencies is precise. As specified in the
+link:src/main/adoc/jlbh-requirements.adoc[jlbh-requirements], JLBH
+generates high-resolution histograms of at least 35 bits. This accuracy
+retains sub-nanosecond resolution over a wide range, so the reported
+percentiles closely reflect true end-to-end timings.
+
 == Articles on Java Latency Benchmarking Harness
 
 http://www.rationaljava.com/2016/04/jlbh-introducing-java-latency.html[Introducting JLBH]


### PR DESCRIPTION
## Summary
- mention 35-bit histogram precision from the requirements in the README

## Testing
- `mvn -q test` *(fails: mvn not found)*