### PR TITLE
Move blog links to further reading

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,8 @@ toc::[]
 == About
 
 Java Latency Benchmark Harness is a tool that allows you to benchmark your code
-running in context, rather than in a microbenchmark. An excellent introduction can be found in
-http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[this series of articles.]
+running in context, rather than in a microbenchmark. See <<further-reading,Further Reading>>
+for a series of articles introducing JLBH.
 
 Since those articles were written the main change has been to allow JLBH to be installed  to an event loop,
 rather than it running in its own thread. To do this, use
@@ -26,9 +26,10 @@ the JLBH.eventLoopHandler method rather than JLBH.start.
 
 JLBH supports single-thread usage only.
 
-== Articles on Java Latency Benchmarking Harness
+[[further-reading]]
+== Further Reading
 
-http://www.rationaljava.com/2016/04/jlbh-introducing-java-latency.html[Introducting JLBH]
+http://www.rationaljava.com/2016/04/jlbh-introducing-java-latency.html[Introducing JLBH]
 
 - What is JLBH
 - What was the motivation for JLBH


### PR DESCRIPTION
## Summary
- add `Further Reading` section
- link to it from the `About` section

## Testing
- `mvn test` *(fails: `mvn` not found)*