### PR TITLE
Clarify JLBHOptions builder use

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,3 +73,17 @@ that is used to execute this type of tests. If the developer's machine is able t
 sufficient performance, this type of test can be run along with all other tests locally. This, in turn
 allows the performance testing to be part of the regular TDD cycle, which helps to discover
 design flaws earlier and often, lowering the development cost of the latency-sensitive applications.
+
+== Quick Start
+
+`JLBHOptions` is configured via a fluent builder pattern so each setter returns the same instance allowing method chaining.
+
+[source,java]
+----
+JLBHOptions options = new JLBHOptions()
+        .throughput(1_000_000)
+        .warmUpIterations(5_000)
+        .iterations(50_000)
+        .jlbhTask(new MyBenchmarkTask());
+----
+


### PR DESCRIPTION
## Summary
- document quick start builder pattern in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*