### PR TITLE
Link README to glossary

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,8 @@ Java Latency Benchmark Harness is a tool that allows you to benchmark your code
 running in context, rather than in a microbenchmark. An excellent introduction can be found in
 http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[this series of articles.]
 
+For terminology used throughout the project, see link:src/main/adoc/jlbh-requirements.adoc#_7-glossary[the Glossary (section 7)].
+
 Since those articles were written the main change has been to allow JLBH to be installed  to an event loop,
 rather than it running in its own thread. To do this, use
 the JLBH.eventLoopHandler method rather than JLBH.start.


### PR DESCRIPTION
## Summary
- crosslink README to glossary section in jlbh-requirements

## Testing
- `mvn -q test` *(fails: `mvn` not found)*