### PR TITLE
Update README with timeout option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,3 +73,7 @@ that is used to execute this type of tests. If the developer's machine is able t
 sufficient performance, this type of test can be run along with all other tests locally. This, in turn
 allows the performance testing to be part of the regular TDD cycle, which helps to discover
 design flaws earlier and often, lowering the development cost of the latency-sensitive applications.
+
+== Options
+
+- `timeout(long)` aborts the benchmark if no samples are produced for the given number of milliseconds.


### PR DESCRIPTION
## Summary
- document `timeout(long)` option in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*