### PR TITLE
Update README bullet phrasing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ http://www.rationaljava.com/2016/04/jlbh-examples-1-why-code-should-be.html[Why 
 http://www.rationaljava.com/2016/04/jlbh-examples-2-accounting-for.html[Accounting for Coordinated Omission]
 
 - Running JLBH with and without accounting for coordinated omission
-- An example to in numbers the effects of coordinated omission
+- An example illustrating the numerical impact of coordinated omission
 - A discussion about flow control
 
 http://www.rationaljava.com/2016/04/jlbh-examples-3-affects-of-throughput.html[The Affects of Throughput on Latency]


### PR DESCRIPTION
## Summary
- fix typo in README: clarify example about coordinated omission

## Testing
- `mvn -q test` *(fails: `mvn` not found)*