### PR TITLE
Update README on single-threaded harness

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ Since those articles were written the main change has been to allow JLBH to be i
 rather than it running in its own thread. To do this, use
 the JLBH.eventLoopHandler method rather than JLBH.start.
 
-JLBH supports single-thread usage only.
+*WARNING:* The JLBH harness itself runs on a single thread; benchmarked code may spawn threads, but the harness thread is unique.
 
 == Articles on Java Latency Benchmarking Harness
 


### PR DESCRIPTION
## Summary
- clarify JLBH harness uses a single thread

## Testing
- `mvn -q test` *(fails: mvn not found)*