### PR TITLE
Add parameter javadoc to sampleNanos method

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
@@ -489,6 +489,11 @@ public class JLBH implements NanoSampler {
         }
     }
 
+    /**
+     * Records a duration sample expressed in nanoseconds.
+     *
+     * @param durationNs duration of the event in nanoseconds
+     */
     @Override
     public void sampleNanos(long durationNs) {
         sample(durationNs);


### PR DESCRIPTION
## Summary
- explain `durationNs` in `JLBH#sampleNanos(long)` javadoc

## Testing
- `mvn -q test` *(fails: `mvn` not found)*