### PR TITLE
Add ProbeResult Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -39,6 +39,14 @@ public interface JLBHResult {
 
     Optional<ProbeResult> osJitter();
 
+    /**
+     * Aggregated latency statistics for a single probe.
+     *
+     * <p>A probe may be executed in multiple runs.  For each run a
+     * {@link RunResult} is recorded and implementations of this interface
+     * expose both the summary of the last run and a list of summaries for all
+     * runs.</p>
+     */
     interface ProbeResult {
 
         @NotNull


### PR DESCRIPTION
## Summary
- add documentation for the ProbeResult interface

## Testing
- `mvn test` *(fails: `mvn` not found)*