### PR TITLE
Add osJitter method javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -37,6 +37,15 @@ public interface JLBHResult {
 
     Set<String> probeNames();
 
+    /**
+     * Returns statistics gathered by the operating system jitter monitor
+     * if it was enabled for the benchmark run.
+     * <p>
+     * When jitter recording was disabled an {@link Optional#empty() empty}
+     * value is returned.
+     *
+     * @return optional OS jitter probe results
+     */
     Optional<ProbeResult> osJitter();
 
     interface ProbeResult {


### PR DESCRIPTION
## Summary
- clarify that `JLBHResult#osJitter()` can return an empty Optional

## Testing
- `mvn -q test` *(fails: `mvn` not found)*