### PR TITLE
Document optional result from probe

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -32,6 +32,16 @@ public interface JLBHResult {
     @NotNull
     ProbeResult endToEnd();
 
+    /**
+     * Returns the results for the given probe name.
+     * <p>
+     * If no probe exists with the supplied name the returned {@code Optional}
+     * will be empty.
+     *
+     * @param probeName name of the probe for which results are requested
+     * @return an {@code Optional} containing the probe results or
+     *         {@link Optional#empty()} if the probe is not present
+     */
     @NotNull
     Optional<ProbeResult> probe(String probeName);
 


### PR DESCRIPTION
## Summary
- clarify Javadoc for `JLBHResult#probe(String)` to mention the returned Optional may be empty

## Testing
- `mvn -q test` *(fails: `mvn` not found)*