### PR TITLE
Add return javadoc for JLBHResult endToEnd

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -29,6 +29,11 @@ import java.util.Set;
 
 public interface JLBHResult {
 
+    /**
+     * Returns the statistics for the end to end latency probe.
+     *
+     * @return probe result summarising the end to end measurements
+     */
     @NotNull
     ProbeResult endToEnd();
 


### PR DESCRIPTION
## Summary
- document return value of `JLBHResult#endToEnd`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*