### PR TITLE
Add Javadoc for timeout option

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHOptions.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHOptions.java
@@ -219,6 +219,16 @@ public class JLBHOptions {
         return this;
     }
 
+    /**
+     * Sets the maximum time to wait for the next sample to be produced.
+     * <p>
+     * If no additional samples are recorded within the specified number of
+     * milliseconds the running benchmark is aborted. A value of {@code 0}
+     * disables the timeout check.
+     *
+     * @param timeout timeout in milliseconds
+     * @return Instance of the JLBHOptions to be used in the builder pattern.
+     */
     public JLBHOptions timeout(long timeout) {
         this.timeout = timeout;
         return this;


### PR DESCRIPTION
## Summary
- document `timeout(long)` explaining sample timeout behaviour

## Testing
- `mvn -q test` *(fails: mvn not found)*