### PR TITLE
Add Javadoc for WarmupHandler

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
@@ -626,6 +626,14 @@ public class JLBH implements NanoSampler {
         }
     }
 
+    /**
+     * Handler executed before the benchmark runs to perform warm-up iterations.
+     * <p>
+     * Each call to {@link #action()} invokes the benchmark task once. When the
+     * configured number of warm-up iterations has been reached the handler
+     * throws {@link InvalidEventHandlerException#reusable()} which removes it
+     * from the event loop and allows the main benchmark handler to start.
+     */
     private final class WarmupHandler implements EventHandler {
         private int iteration;
 


### PR DESCRIPTION
## Summary
- document warm-up handling logic in `WarmupHandler`

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*