### PR TITLE
Add javadoc for LatencyDistributors

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributors.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributors.java
@@ -20,6 +20,16 @@ package net.openhft.chronicle.jlbh;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Predefined strategies used to vary the latency applied by JLBH.
+ * <ul>
+ *     <li>{@link #NORMAL} - return the supplied latency unchanged.</li>
+ *     <li>{@link #RANDOM} - choose a value uniformly between one microsecond
+ *     and roughly twice the average.</li>
+ *     <li>{@link #RANDOM2} - skewed random distribution that favours smaller
+ *     values but can return up to about four times the average latency.</li>
+ * </ul>
+ */
 public enum LatencyDistributors implements LatencyDistributor {
     NORMAL {
         @Override


### PR DESCRIPTION
## Summary
- document LatencyDistributors enum

## Testing
- `javac -d /tmp/classes $(find src/main/java -name '*.java')` *(fails: package net.openhft.affinity does not exist)*