### PR TITLE
Document input and output for LatencyDistributor#apply

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributor.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributor.java
@@ -20,5 +20,13 @@ package net.openhft.chronicle.jlbh;
 
 @FunctionalInterface
 public interface LatencyDistributor {
+    /**
+     * Adjust the delay between benchmark iterations.
+     *
+     * @param averageLatencyNS the nominal delay in nanoseconds derived from the
+     *                          configured throughput
+     * @return the actual number of nanoseconds to wait before the next
+     *         iteration is executed
+     */
     long apply(long averageLatencyNS);
 }


### PR DESCRIPTION
## Summary
- clarify usage of LatencyDistributor#apply in the code

## Testing
- `mvn -q test` *(fails: `mvn` not found)*