### PR TITLE
Document return value of get

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
@@ -33,6 +33,11 @@ final class ThreadSafeJLBHResultConsumer implements JLBHResultConsumer {
         this.result = result;
     }
 
+    /**
+     * Returns the result previously supplied via {@link #accept(JLBHResult)}.
+     *
+     * @return the last accepted {@link JLBHResult}, or {@code null} if none has been provided
+     */
     @Override
     public JLBHResult get() {
         return result;


### PR DESCRIPTION
## Summary
- describe the return value of `ThreadSafeJLBHResultConsumer#get()`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*