### PR TITLE
Add Javadoc for ThreadSafeJLBHResultConsumer

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
@@ -16,8 +16,18 @@
  * limitations under the License.
  *
  */
+
 package net.openhft.chronicle.jlbh;
 
+/**
+ * {@link JLBHResultConsumer} implementation that stores the last result in a
+ * {@code volatile} field.
+ *
+ * <p>The accepted {@link JLBHResult} is expected to be immutable. Storing it in
+ * a {@code volatile} variable ensures that once {@link #accept(JLBHResult)}
+ * returns, any thread invoking {@link #get()} will observe the same instance
+ * without further synchronisation.</p>
+ */
 final class ThreadSafeJLBHResultConsumer implements JLBHResultConsumer {
 
     // the assumption is that the JLBHResult is immutable


### PR DESCRIPTION
## Summary
- add class level Javadoc to ThreadSafeJLBHResultConsumer

## Testing
- `mvn -q test` *(fails: `mvn` not found)*