### PR TITLE
Add constructor Javadoc for ImmutableProbeResult

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/ImmutableProbeResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ImmutableProbeResult.java
@@ -30,6 +30,17 @@ final class ImmutableProbeResult implements JLBHResult.ProbeResult {
     @NotNull
     private final List<JLBHResult.RunResult> runsSummary;
 
+    /**
+     * Construct a probe result from the percentile values collected during each
+     * benchmark run.
+     *
+     * <p>The {@code percentileRuns} list should contain one array for every run
+     * of the benchmark. Each array is expected to be the values returned by a
+     * {@link net.openhft.chronicle.core.util.Histogram#getPercentiles()} call,
+     * i.e. latency percentiles in nanoseconds.</p>
+     *
+     * @param percentileRuns list of percentile arrays for each run
+     */
     public ImmutableProbeResult(List<double[]> percentileRuns) {
         runsSummary = unmodifiableList(percentileRuns.stream().map(ImmutableRunResult::new).collect(toList()));
     }


### PR DESCRIPTION
## Summary
- document the expected percentile run list in `ImmutableProbeResult` constructor

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*