### PR TITLE
Add Javadoc for RunResult#getWorst()

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -127,6 +127,11 @@ public interface JLBHResult {
         @Nullable
         Duration get9999thPercentile();
 
+        /**
+         * Returns the maximum latency observed during this run.
+         *
+         * @return the duration of the slowest event
+         */
         @NotNull
         Duration getWorst();
 


### PR DESCRIPTION
## Summary
- document the getter that exposes the worst latency for a run

## Testing
- `mvn -q test` *(fails: `mvn` not found)*