### PR TITLE
Add Javadoc for RunResult#get999thPercentile

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -121,6 +121,11 @@ public interface JLBHResult {
         @NotNull
         Duration get99thPercentile();
 
+        /**
+         * Returns the 99.9th percentile latency recorded for this run.
+         *
+         * @return 99.9th percentile latency or {@code null} if the percentile was not collected
+         */
         @Nullable
         Duration get999thPercentile();
 


### PR DESCRIPTION
## Summary
- document `RunResult#get999thPercentile()`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*