### PR TITLE
Add Javadoc for RunResult 99th percentile

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -118,6 +118,11 @@ public interface JLBHResult {
         @NotNull
         Duration get90thPercentile();
 
+        /**
+         * Obtain the latency recorded at the 99th percentile for the run.
+         *
+         * @return duration representing the 99th percentile
+         */
         @NotNull
         Duration get99thPercentile();
 


### PR DESCRIPTION
## Summary
- document RunResult#get99thPercentile in JLBHResult

## Testing
- `mvn -q test` *(fails: `mvn` not found)*