### PR TITLE
Add javadoc for 90th percentile getter

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -115,6 +115,11 @@ public interface JLBHResult {
         @NotNull
         Duration get50thPercentile();
 
+        /**
+         * Obtain the latency at the 90th percentile of all recorded values.
+         *
+         * @return 90th percentile latency
+         */
         @NotNull
         Duration get90thPercentile();
 


### PR DESCRIPTION
## Summary
- document `RunResult#get90thPercentile()`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*