### PR TITLE
Add javadoc for RunResult percentiles map

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -109,6 +109,27 @@ public interface JLBHResult {
 
     interface RunResult {
 
+        /**
+         * Returns the latency recorded for each measured percentile.
+         *
+         * <p>The returned map is keyed by {@link Percentile} values and the
+         * associated {@link Duration} represents the observed latency at that
+         * percentile. Expected keys include
+         * {@link Percentile#PERCENTILE_50TH 50th},
+         * {@link Percentile#PERCENTILE_90TH 90th},
+         * {@link Percentile#PERCENTILE_99TH 99th},
+         * {@link Percentile#PERCENTILE_99_7TH 99.7th},
+         * {@link Percentile#PERCENTILE_99_9TH 99.9th},
+         * {@link Percentile#PERCENTILE_99_97TH 99.97th},
+         * {@link Percentile#PERCENTILE_99_99TH 99.99th},
+         * {@link Percentile#PERCENTILE_99_999TH 99.999th}, and
+         * {@link Percentile#WORST WORST} for the highest latency.</p>
+         *
+         * <p>Percentiles that are not measured for a particular run may be
+         * absent from the map.</p>
+         *
+         * @return mapping of percentile identifiers to latency values
+         */
         @NotNull
         Map<Percentile, Duration> percentiles();
 


### PR DESCRIPTION
## Summary
- document the map returned by `RunResult#percentiles`
- list the percentile keys and clarify WORST entry

## Testing
- `mvn -q test` *(fails: `mvn` not found)*