### PR TITLE
Add Javadoc for RunResult

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -107,6 +107,13 @@ public interface JLBHResult {
         List<RunResult> eachRunSummary();
     }
 
+    /**
+     * Latency metrics recorded for a single run of a probe.
+     *
+     * <p>Implementations expose the commonly used percentile values as
+     * {@link Duration} instances and also provide access to the entire set of
+     * calculated percentiles via {@link #percentiles()}.</p>
+     */
     interface RunResult {
 
         @NotNull


### PR DESCRIPTION
## Summary
- document `JLBHResult.RunResult`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*