### PR TITLE
Add return description for eachRunSummary

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -103,6 +103,11 @@ public interface JLBHResult {
         @NotNull
         RunResult summaryOfLastRun();
 
+        /**
+         * Obtain the summary statistics for each run of this probe.
+         *
+         * @return list of run summaries in execution order
+         */
         @NotNull
         List<RunResult> eachRunSummary();
     }


### PR DESCRIPTION
## Summary
- document return value of `ProbeResult#eachRunSummary`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*