### PR TITLE
Clarify immutability requirement

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
@@ -20,13 +20,18 @@ package net.openhft.chronicle.jlbh;
 
 final class ThreadSafeJLBHResultConsumer implements JLBHResultConsumer {
 
-    // the assumption is that the JLBHResult is immutable
+    // The stored JLBHResult must be immutable so it can be safely published
+    // to other threads without additional synchronisation.
     private volatile JLBHResult result;
 
     /**
-     * Must be immutable.
+     * Stores the provided result for retrieval from other threads.
+     * <p>
+     * The {@code result} <strong>must</strong> be immutable as the consumer
+     * keeps only a reference to it. Any subsequent mutation would break the
+     * thread-safety guarantees.
      *
-     * @param result Result provided by the JLBH
+     * @param result Result provided by the JLBH; must not be mutable
      */
     @Override
     public void accept(JLBHResult result) {


### PR DESCRIPTION
## Summary
- improve documentation on immutable requirement for `ThreadSafeJLBHResultConsumer.accept`

## Testing
- ❌ `mvn -q test` *(failed: mvn not found)*