### PR TITLE
Add Javadoc for jitter monitor init

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
@@ -340,6 +340,15 @@ public class JLBH implements NanoSampler {
         jlbhOptions.jlbhTask.warmedUp();
     }
 
+    /**
+     * Initialise the configured {@link JLBHTask} and start jitter monitoring.
+     * <p>
+     * The task's {@link JLBHTask#init(JLBH)} method is invoked giving it an
+     * opportunity to create any additional probes via {@link #addProbe(String)}.
+     * If {@link JLBHOptions#recordOSJitter} is enabled a background
+     * {@link OSJitterMonitor} thread is started to record operating system
+     * scheduling jitter.
+     */
     private void initStartOSJitterMonitor() {
         jlbhOptions.jlbhTask.init(this);
         if (jlbhOptions.recordOSJitter) {


### PR DESCRIPTION
## Summary
- document OS jitter monitor startup sequence in `initStartOSJitterMonitor`

## Testing
- `mvn` was not available so no tests were run