### PR TITLE
Add Chronicle package summary

### DIFF
--- a/src/main/java/net/openhft/chronicle/package-info.java
+++ b/src/main/java/net/openhft/chronicle/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * The {@code net.openhft.chronicle} packages contain the Chronicle stack of
+ * low-latency libraries.
+ *
+ * <p>Major open-source subprojects include:</p>
+ * <ul>
+ *   <li>{@code chronicle-core} - concurrency and operating-system utilities.</li>
+ *   <li>{@code chronicle-bytes} - direct and off-heap byte management.</li>
+ *   <li>{@code chronicle-wire} - zero-copy serialisation and marshalling.</li>
+ *   <li>{@code chronicle-queue} - persisted messaging and event storage.</li>
+ *   <li>{@code chronicle-map} - off-heap key-value store.</li>
+ *   <li>{@code chronicle-network} - asynchronous network transport.</li>
+ * </ul>
+ *
+ * <p>{@link net.openhft.chronicle.jlbh.JLBH JLBH} builds upon Chronicle Core to
+ * provide a high resolution latency benchmark harness.</p>
+ */
+package net.openhft.chronicle;


### PR DESCRIPTION
## Summary
- describe Chronicle subprojects in `package-info.java`
- link from `net.openhft.chronicle` to `JLBH`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*
