### PR TITLE
Add package-info for OpenHFT namespace

### DIFF
--- a/src/main/java/net/openhft/package-info.java
+++ b/src/main/java/net/openhft/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Root of the OpenHFT namespace.
+ *
+ * <p>All Chronicle libraries share this package prefix.  Each module adds its
+ * own subpackages while relying on a common naming convention.
+ */
+package net.openhft;


### PR DESCRIPTION
## Summary
- document the OpenHFT root package

## Testing
- `mvn -q verify` *(fails: command not found)*