### PR TITLE
Add coverage tests and align documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,12 +77,12 @@ Commonly used option methods include:
 
 For a full list of configuration parameters see `src/main/java/net/openhft/chronicle/jlbh/JLBHOptions.java`.
 
-For a visual overview of how a benchmark progresses, see the link:docs/benchmark-lifecycle.adoc[benchmark lifecycle diagram].
+For a visual overview of how a benchmark progresses, see the link:src/main/adoc/benchmark-lifecycle.adoc[benchmark lifecycle diagram].
 
 == Additional Features
 
 === OS Jitter Measurement
-JLBH can optionally track operating-system jitter by running a background thread that records scheduler delays as a separate probe. This is useful when investigating latency spikes caused by kernel activity, but it incurs some overhead so it is disabled by default. You can enable it via `recordOSJitter()` when you need to quantify such noise. The feature is listed in the requirements specification around lines 52 and 56 of `project-requirements.adoc`.
+JLBH can optionally track operating-system jitter by running a background thread that records scheduler delays as a separate probe. This is useful when investigating latency spikes caused by kernel activity, but it incurs some overhead so it is enabled by default. Disable it via `recordOSJitter(false)` when you want to avoid the extra monitoring. The feature is listed in the requirements specification around lines 52 and 56 of `project-requirements.adoc`.
 
 === Adding custom probes
 JLBH lets you time additional stages of your benchmark using `addProbe(String)`. The returned `NanoSampler` records its own histogram.
@@ -147,11 +147,11 @@ The following table summarises the main non-functional quality attributes derive
 |===
 | Area | Requirement
 
-| Performance | Overhead per sample must remain below 100 ns when no additional probes are active. Histogram generation must support ≥200 M iterations without heap pressure.
+| Performance | Overhead per sample must remain below 100 ns when no additional probes are active. Histogram generation must support >=200 M iterations without heap pressure.
 | Reliability | Harness must abort gracefully on interruptions or sample time-outs, and immutable result objects ensure thread-safe publication.
 | Usability | Fluent builder API with sensible defaults yields a runnable benchmark in ≤10 LOC. ASCII table outputs are human-readable and CI-friendly.
 | Portability | Pure-Java codebase with runtime-detected JDK optimisations; no native compilation.
-| Maintainability | ≥80 % unit-test coverage and adherence to Chronicle coding standards validated by SonarCloud.
+| Maintainability | >=80 % unit-test coverage and adherence to Chronicle coding standards validated by SonarCloud.
 | Security | No executable deserialisation; harness operates in-process. Users remain responsible for securing benchmarked code.
 |===
 
@@ -229,4 +229,4 @@ Configure the target rate using `throughput(int, TimeUnit)` and optionally a `La
 
 == Licensing and Release Information
 
-The code is licensed under the terms described in the link:LICENSE[Apache 2.0 License]. Releases are available on link:https://github.com/OpenHFT/JLBH/releases[GitHub].
+The code is licensed under the terms described in the link:LICENSE.adoc[Apache 2.0 License]. Releases are available on link:https://github.com/OpenHFT/JLBH/releases[GitHub].

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,19 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <showWarnings>true</showWarnings>
+                    <failOnWarning>false</failOnWarning>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+
             <!--
                 generate maven dependencies versions file that can be used later
                 to install the right bundle in test phase.
@@ -163,6 +176,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>enforce-release-8</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+    </profiles>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,27 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/adoc/architecture.adoc
+++ b/src/main/adoc/architecture.adoc
@@ -77,7 +77,7 @@ The `startTimeNs` is the calculated ideal start time for the iteration.
 
 * `OSJitterMonitor`
 ** An internal background thread responsible for measuring operating system scheduling jitter.
-** Activated if `JLBHOptions.recordOSJitter` is true.
+** Monitoring is enabled by default (`JLBHOptions.recordOSJitter` defaults to true) and can be disabled via `recordOSJitter(false)`.
 ** Repeatedly calls `System.nanoTime()` to detect delays greater than `recordJitterGreaterThanNs` and records these into a dedicated `Histogram`.
 
 == 3. Execution Flow
@@ -140,6 +140,7 @@ JLBH has a specific threading model that users and contributors should understan
 
 * **Event Loop Integration**:
 ** As an alternative to `JLBH.start()`, the benchmark can be driven by an external `EventLoop` (e.g., from Chronicle Services) by calling `JLBH.eventLoopHandler(EventLoop)`.
+** Coordinated omission accounting must remain enabled; calling `eventLoopHandler` with `accountForCoordinatedOmission(false)` throws an `UnsupportedOperationException`.
 ** In this mode, the warm-up and measurement iterations are scheduled and executed on the provided event loop's thread, using internal `EventHandler` implementations (`WarmupHandler`, `JLBHEventHandler`).
 
 * **User-Spawned Threads within `JLBHTask`**:

--- a/src/main/adoc/benchmark-lifecycle.adoc
+++ b/src/main/adoc/benchmark-lifecycle.adoc
@@ -22,7 +22,7 @@ This initial phase prepares the benchmark environment:
 * **Task Initialization**: The `JLBHTask.init(JLBH jlbh)` method of the user-provided task is invoked.
 ** This allows the benchmark task to perform its own one-time setup, such as initializing resources or fixtures.
 ** Crucially, this is where additional measurement probes can be registered by calling `jlbh.addProbe("probeName")` to get `NanoSampler` instances for specific sub-sections of the task.
-* **OS Jitter Monitoring**: If configured in `JLBHOptions` (`recordOSJitter = true`), the `OSJitterMonitor` background thread is started to begin measuring operating system scheduling jitter independently.
+* **OS Jitter Monitoring**: Jitter tracking is enabled by default (`recordOSJitter` defaults to true); unless disabled via `recordOSJitter(false)`, the `OSJitterMonitor` background thread starts to measure operating system scheduling jitter independently.
 * **Affinity**: If an `acquireLock` supplier is configured in `JLBHOptions`, an attempt to acquire CPU affinity for the main benchmark thread might occur.
 
 == 2. Warmup

--- a/src/main/adoc/decision-log.adoc
+++ b/src/main/adoc/decision-log.adoc
@@ -32,6 +32,6 @@ Rationale for Decision::
 Impact & Consequences::
 * Contributors must learn basic AsciiDoc syntax.
 * Build pipeline processes `.adoc` files to publish HTML.
-- Some external tools may expect Markdown, requiring conversion.
+* Some external tools may expect Markdown, requiring conversion.
 Notes/Links::
 ** https://asciidoctor.org[AsciiDoc project page]

--- a/src/main/adoc/jlbh-cookbook.adoc
+++ b/src/main/adoc/jlbh-cookbook.adoc
@@ -520,8 +520,8 @@ public class MainApp {
                 .iterations(10_000)   // Shorter for quick demo
                 .throughput(50_000)
                 .jlbhTask(new CallBenchmark())
-                // Enable OS Jitter recording
-                .recordOSJitter(true)
+                // OS jitter recording is enabled by default; use recordOSJitter(false)
+                // if you want to disable the background monitor.
                 // Optional: Only record jitter events greater than a specific threshold (default 1_000 ns)
                 // .recordJitterGreaterThanNs(5_000)
                 // Optional: Pin the OS Jitter monitoring thread to a specific CPU core (if supported)
@@ -535,7 +535,8 @@ public class MainApp {
 
 *Interpreting OS Jitter Results*:
 
-* When `recordOSJitter(true)` is set, JLBH starts a background thread that continuously measures the time elapsed between calls to `System.nanoTime()`.
+* JLBH records OS jitter by default and starts a background thread that continuously measures the time elapsed between calls to `System.nanoTime()`.
+Use `recordOSJitter(false)` only when you want to suppress this monitoring.
 * If this measured gap exceeds `recordJitterGreaterThanNs`, it's considered an OS-induced pause/jitter event and is recorded in a special "OS Jitter" probe.
 * The JLBH output (both console and `JLBHResult`) will include a section for the "OS Jitter" probe, showing its own percentile distribution.
 * These jitter values represent pauses that are *not* caused by your application code but by the operating system or other processes interfering with the JLBH process's execution.

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -1,4 +1,4 @@
-= Chronicle JLBH – Software Requirements Specification
+= Chronicle JLBH - Software Requirements Specification
 Chronicle Software
 :revnumber: 1.0
 :revdate: 23 May 2025
@@ -7,13 +7,13 @@ Chronicle Software
 
 *_Abstract_*::
 Chronicle JLBH is an open-source Java library, released under the Apache Licence 2.0, that provides a high-resolution latency benchmark harness.
-It allows developers to _measure_, _analyse_ and _regress-test_ latency behaviour of critical code paths “in context” rather than via isolated micro-benchmarks.
+It allows developers to _measure_, _analyse_ and _regress-test_ latency behaviour of critical code paths "in context" rather than via isolated micro-benchmarks.
 Key features include compensation for *co-ordinated omission*, configurable throughput modelling, additional probes, optional operating-system jitter tracking, and serialisation of results for CI dashboards.
 
 == 1. Introduction
 
 === 1.1 Purpose
-This document specifies functional and non-functional requirements for Chronicle JLBH, ensuring that contributors and integrators share a common understanding of the product’s goals and constraints.
+This document specifies functional and non-functional requirements for Chronicle JLBH, ensuring that contributors and integrators share a common understanding of the product's goals and constraints.
 
 === 1.2 Scope
 The harness targets _low-latency_ Java applications (trading systems, micro-services, real-time analytics) that must quantify latencies at extreme percentiles under realistic load patterns.
@@ -23,7 +23,7 @@ The harness targets _low-latency_ Java applications (trading systems, micro-serv
 |===
 | *Term* | *Definition*
 
-| JLBH | Java Latency Benchmark Harness – the library under specification.
+| JLBH | Java Latency Benchmark Harness - the library under specification.
 | Co-ordinated Omission | Measurement error whereby pauses/back-pressure hide worst-case latencies.
 | Probe | A named histogram that records an additional timing within the benchmark workflow.
 | OS Jitter | Kernel or scheduler-induced timing variance measured by a background thread.
@@ -32,14 +32,14 @@ The harness targets _low-latency_ Java applications (trading systems, micro-serv
 
 === 1.4 References
 
-* Upstream repository: https://github.com/OpenHFT/JLBH[GitHub – OpenHFT/JLBH]
+* Upstream repository: https://github.com/OpenHFT/JLBH[GitHub - OpenHFT/JLBH]
 * API reference: https://javadoc.io/doc/net.openhft/chronicle-core/latest/net/openhft/chronicle/core/jlbh/JLBH.html[Javadoc]
 * Tutorial series: http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[RationalJava blog series]
 * Discussion of _co-ordinated omission_: https://groups.google.com/g/mechanical-sympathy/c/icNZJejUHfE[m.s. thread]
 * Chronicle blog post on JLBH in event loops: https://vanilla-java.github.io/2016/04/02/Microservices-in-the-Chronicle-World-Part-5.html[Vanilla-Java article]
 
 === 1.5 Overview
-Sections 2–5 describe the product context, interfaces, detailed system features, and quality attributes.
+Sections 2-5 describe the product context, interfaces, detailed system features, and quality attributes.
 Section 6 captures licensing, whilst Section 7 presents the glossary.
 
 == 2. Overall Description
@@ -49,7 +49,7 @@ JLBH is delivered as a *Maven* artefact (`net.openhft:jlbh`) and depends on Chro
 
 === 2.2 Product Functions
 
-* Generate high-resolution histograms (≥35 bits) of end-to-end sample latencies.
+* Generate high-resolution histograms (>=35 bits) of end-to-end sample latencies.
 * Optionally compensate for *co-ordinated omission* by adjusting the synthetic start time.
 * Model load via configurable `throughput(int, TimeUnit)` and *LatencyDistributor*s.
 * Provide additional named probes via `addProbe(String)`.
@@ -92,11 +92,11 @@ JLBH is delivered as a *Maven* artefact (`net.openhft:jlbh`) and depends on Chro
 
 === 3.1 Public API
 
-* `JLBHOptions` – builder for benchmark parameters (throughput, warm-up, runs, etc.).
-* `JLBHTask` – user-defined callback with lifecycle methods `init`, `run`, `warmedUp`, `runComplete`, `complete`.
-* `JLBH` – orchestrator class with `start()` and `eventLoopHandler(EventLoop)` entry points.
-* `JLBHResult` – immutable projection of measured data.
-* `JLBHResultSerializer` – CSV writer for analytics pipelines.
+* `JLBHOptions` - builder for benchmark parameters (throughput, warm-up, runs, etc.).
+* `JLBHTask` - user-defined callback with lifecycle methods `init`, `run`, `warmedUp`, `runComplete`, `complete`.
+* `JLBH` - orchestrator class with `start()` and `eventLoopHandler(EventLoop)` entry points.
+* `JLBHResult` - immutable projection of measured data.
+* `JLBHResultSerializer` - CSV writer for analytics pipelines.
 
 === 3.2 User Interface
 CLI usage is demonstrated in _ExampleJLBHMain_ and test fixtures; no dedicated GUI is provided.
@@ -113,54 +113,54 @@ None. The harness interacts with OS timers and CPU affinity via JNI where availa
 
 == 4. System Features
 
-=== 4.1 Latency Sampling
+=== 4.1 FN-001 Latency Sampling
 *Description*: Collect nanosecond deltas from user code via `sample(long)` or `sampleNanos(long)`.
 *Stimulus/Response*: Upon each iteration, `JLBHTask.run` calls `jlbh.sample(...)`; histogram updates occur; run summary printed at completion.
 *Priority*: *Essential*.
 
-=== 4.2 Coordinated-Omission Compensation
+=== 4.2 FN-002 Coordinated-Omission Compensation
 Ensures that queue back-log does not under-represent tail latency. Enabled by default; opt-out via `accountForCoordinatedOmission(false)`.
 
-=== 4.3 Additional Probes
+=== 4.3 FN-003 Additional Probes
 Developers may time sub-stages (e.g., serialisation, network round-trip) through `addProbe(String)` and record them independently.
 
-=== 4.4 OS Jitter Tracking
-A background thread measures scheduling gaps exceeding a configured threshold (`recordJitterGreaterThanNs`). Results are summarised alongside core latencies.
+=== 4.4 FN-004 OS Jitter Tracking
+A background thread measures scheduling gaps exceeding a configured threshold (`recordJitterGreaterThanNs`). Monitoring is enabled by default and can be disabled via `recordOSJitter(false)`. Results are summarised alongside core latencies.
 
-=== 4.5 CSV Serialisation
+=== 4.5 FN-005 CSV Serialisation
 Post-run, results can be persisted for offline analysis (`result.csv` by default).
 
-=== 4.6 Event Loop Integration
+=== 4.6 FN-006 Event Loop Integration
 `eventLoopHandler(EventLoop)` allows benchmarks to operate inside Chronicle threading framework, avoiding extra threads.
 
 == 5. Non-Functional Requirements
 
-=== 5.1 Performance
+=== 5.1 NF-P-001 Performance
 * Overhead per sample must remain below 100 ns when no additional probes are active.
-* Histogram generation must support ≥200 M iterations without heap pressure.
+* Histogram generation must support >=200 M iterations without heap pressure.
 
-=== 5.2 Reliability
+=== 5.2 NF-R-001 Reliability
 * Harness must abort gracefully on thread interruptions or sample time-outs (`timeout(long)`).
 * Immutable result objects ensure thread-safe publication to external consumers.
 
-=== 5.3 Usability
+=== 5.3 NF-UX-001 Usability
 * Fluent builder API; sensible defaults provide a runnable benchmark in ≤10 LOC.
 * ASCII table outputs are human-readable and CI-friendly.
 
-=== 5.4 Portability
+=== 5.4 NF-O-001 Portability
 * Pure-Java codebase; no native compilation steps.
 * JDK-specific optimisations (e.g., *Zing* support) are runtime-detected.
 
-=== 5.5 Maintainability
+=== 5.5 NF-O-002 Maintainability
 * 80 %+ unit-test line coverage with deterministic fixtures.
 * Code adheres to Chronicle parent POM style and SonarCloud quality gates.
 
-=== 5.6 Security
+=== 5.6 NF-S-001 Security
 No executable deserialisation; harness operates in-process. Users remain responsible for securing benchmarked code.
 
 == 6. Licensing
 
-The project is released under the *Apache Licence 2.0* (_see_ `LICENSE`).
+The project is released under the *Apache Licence 2.0* (_see_ `LICENSE.adoc`).
 Downstream consumers must preserve licence notices and may include JLBH in commercial or OSS products, subject to the terms therein.
 
 == 7. Glossary
@@ -169,7 +169,7 @@ Co-ordinated Omission:: Statistical artefact causing under-reporting of worst-ca
 Histogram:: Data structure that records frequency counts in logarithmic buckets, enabling percentile extraction.
 Percentile:: Value below which a given percentage of observations fall (e.g., 99th percentile).
 
-== 8. Appendix A – Example Minimal Benchmark
+== 8. Appendix A - Example Minimal Benchmark
 
 [source,java]
 ----
@@ -189,10 +189,10 @@ public class NothingBenchmark implements JLBHTask {
 }
 ----
 
-== 9. Appendix B – Footnotes
+== 9. Appendix B - Footnotes
 
-* JLBH originated within the Chronicle Software open-source stack and is actively maintained.footnote:[Project home — GitHub repository:contentReference[oaicite:1]]
-* The API reference highlights the focus on _co-ordinated omission_ and event-loop support.footnote:[Javadoc for class `JLBH`:contentReference[oaicite:2]]
-* A multi-part blog series gives practical guidance on designing realistic latency tests.footnote:[RationalJava series:contentReference[oaicite:3]]
-* Vanilla-Java’s micro-services article demonstrates embedding JLBH in an event-driven architecture.footnote:[Vanilla-Java blog:contentReference[oaicite:4]]
-* Original discussion of co-ordinated omission by Gil Tene motivates JLBH’s default settings.footnote:[Mechanical Sympathy thread:contentReference[oaicite:5]]
+* JLBH originated within the Chronicle Software open-source stack and is actively maintained. See https://github.com/OpenHFT/JLBH.
+* The API reference highlights the focus on _co-ordinated omission_ and event-loop support. See https://www.javadoc.io/doc/net.openhft/chronicle-core/latest/net/openhft/chronicle/jlbh/JLBH.html.
+* A multi-part blog series gives practical guidance on designing realistic latency tests. See http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html.
+* Vanilla-Java's micro-services article demonstrates embedding JLBH in an event-driven architecture. See https://vanilla-java.github.io/2016/04/02/Microservices-in-the-Chronicle-World-Part-5.html.
+* Original discussion of co-ordinated omission by Gil Tene motivates JLBH's default settings. See https://groups.google.com/g/mechanical-sympathy/c/icNZJejUHfE.

--- a/src/main/adoc/results-interpretation-guide.adoc
+++ b/src/main/adoc/results-interpretation-guide.adoc
@@ -66,7 +66,7 @@ Co-ordinated Omission is a critical concept in latency measurement, especially f
 JLBH can optionally measure Operating System (OS) jitter, which refers to delays caused by the OS scheduler or other system activities interrupting the benchmark process.
 
 * **Mechanism**:
-** When `recordOSJitter = true` in `JLBHOptions`, a dedicated background thread (`OSJitterMonitor`) is started.
+** Jitter monitoring is enabled by default (`recordOSJitter` defaults to true); a dedicated background thread (`OSJitterMonitor`) starts unless you explicitly disable it with `recordOSJitter(false)`.
 ** This thread repeatedly calls `System.nanoTime()` in a tight loop and measures the time difference between consecutive calls.
 ** If this difference (a "gap") exceeds a configurable threshold (`recordJitterGreaterThanNs`, default 1 microsecond), it's recorded as an OS jitter event in a separate "OS Jitter" histogram.
 * **Interpreting Jitter Output**:

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
@@ -1,7 +1,6 @@
 package net.openhft.chronicle.jlbh;
 
 import net.openhft.chronicle.core.util.NanoSampler;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
@@ -1,0 +1,185 @@
+package net.openhft.chronicle.jlbh;
+
+import net.openhft.chronicle.core.util.NanoSampler;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class JLBHAdditionalCoverageTest {
+    /**
+     * Exercises {@link JLBH#abort()} to ensure the running harness can be stopped safely.
+     */
+    @Test
+    public void shouldAbortWhenRequested() {
+        AbortOnRunTask task = new AbortOnRunTask();
+        JLBHOptions options = newHarness(task)
+                .warmUpIterations(2)
+                .iterations(20)
+                .runs(5);
+        JLBH jlbh = new JLBH(options, silentPrintStream(), JLBHResultConsumer.newThreadSafeInstance());
+
+        jlbh.start();
+
+        assertTrue("abort was not triggered", task.abortCount() > 0);
+        assertTrue("task should finish quickly after abort", task.totalRuns() < 5 * 20);
+    }
+
+    /**
+     * Verifies that configuring a timeout starts the watchdog thread without error.
+     */
+    @Test
+    public void shouldStartTimeoutCheckerWhenTimeoutConfigured() {
+        CountingTask task = new CountingTask();
+        JLBHOptions options = newHarness(task)
+                .warmUpIterations(1)
+                .iterations(5)
+                .runs(1)
+                .timeout(1)
+                .recordOSJitter(false);
+        JLBH jlbh = new JLBH(options, silentPrintStream(), JLBHResultConsumer.newThreadSafeInstance());
+
+        jlbh.start();
+
+        assertTrue("samples should have been recorded", task.totalRuns() >= 1);
+    }
+
+    /**
+     * Ensures {@link JLBH#eventLoopHandler(net.openhft.chronicle.core.threads.EventLoop)} rejects use when
+     * coordinated omission compensation is disabled.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldRejectEventLoopWhenCoordinatedOmissionDisabled() {
+        JLBHOptions options = newHarness(new NoOpTask())
+                .accountForCoordinatedOmission(false)
+                .recordOSJitter(false);
+        JLBH jlbh = new JLBH(options, silentPrintStream(), null);
+        jlbh.eventLoopHandler(null);
+    }
+
+    /**
+     * Covers helper methods that format percentile output.
+     */
+    @Test
+    public void shouldFormatRunSummaries() throws Exception {
+        JLBHOptions options = newHarness(new NoOpTask());
+        JLBH jlbh = new JLBH(options, silentPrintStream(), null);
+        Method addPr = JLBH.class.getDeclaredMethod("addPrToPrint", StringBuilder.class, String.class, int.class);
+        addPr.setAccessible(true);
+        StringBuilder sb = new StringBuilder();
+        addPr.invoke(jlbh, sb, "99.9:     ", 2);
+        assertEquals("99.9:     %12.2f %12.2f %12.2f%n", sb.toString());
+
+        Method header = JLBH.class.getDeclaredMethod("generateRunSummaryHeader", int.class);
+        header.setAccessible(true);
+        assertEquals("Percentile   run1         run2      % Variation", header.invoke(jlbh, 2));
+
+        Method unit = JLBH.class.getDeclaredMethod("timeUnitToString", TimeUnit.class);
+        unit.setAccessible(true);
+        assertEquals("ns", unit.invoke(jlbh, TimeUnit.NANOSECONDS));
+        assertEquals("us", unit.invoke(jlbh, TimeUnit.MICROSECONDS));
+        assertEquals("ms", unit.invoke(jlbh, TimeUnit.MILLISECONDS));
+        assertEquals("s", unit.invoke(jlbh, TimeUnit.SECONDS));
+        assertEquals("min", unit.invoke(jlbh, TimeUnit.MINUTES));
+        assertEquals("h", unit.invoke(jlbh, TimeUnit.HOURS));
+        assertEquals("day", unit.invoke(jlbh, TimeUnit.DAYS));
+    }
+
+    private static JLBHOptions newHarness(JLBHTask task) {
+        return new JLBHOptions()
+                .warmUpIterations(1)
+                .iterations(1)
+                .throughput(10_000)
+                .runs(1)
+                .recordOSJitter(false)
+                .jlbhTask(task);
+    }
+
+    private static PrintStream silentPrintStream() {
+        return new PrintStream(new ByteArrayOutputStream());
+    }
+
+    private static final class AbortOnRunTask implements JLBHTask {
+        private JLBH jlbh;
+        private final AtomicInteger count = new AtomicInteger();
+        private final AtomicInteger abortCount = new AtomicInteger();
+        private final AtomicInteger totalRuns = new AtomicInteger();
+
+        @Override
+        public void init(JLBH jlbh) {
+            this.jlbh = jlbh;
+        }
+
+        @Override
+        public void run(long startTimeNs) {
+            int current = count.incrementAndGet();
+            long duration = Math.max(0, System.nanoTime() - startTimeNs);
+            jlbh.sample(duration);
+            if (current == 10) {
+                abortCount.incrementAndGet();
+                jlbh.abort();
+            }
+            totalRuns.incrementAndGet();
+        }
+
+        @Override
+        public void complete() {
+            // no-op
+        }
+
+        int abortCount() {
+            return abortCount.get();
+        }
+
+        int totalRuns() {
+            return totalRuns.get();
+        }
+    }
+
+    private static final class CountingTask implements JLBHTask {
+        private final AtomicInteger totalRuns = new AtomicInteger();
+        private JLBH harness;
+        private NanoSampler sampler;
+
+        @Override
+        public void init(JLBH jlbh) {
+            this.harness = jlbh;
+            this.sampler = jlbh.addProbe("count");
+        }
+
+        @Override
+        public void run(long startTimeNs) {
+            totalRuns.incrementAndGet();
+            long duration = System.nanoTime() - startTimeNs;
+            harness.sample(duration);
+            sampler.sampleNanos(duration);
+        }
+
+        @Override
+        public void complete() {
+            // no-op
+        }
+
+        int totalRuns() {
+            return totalRuns.get();
+        }
+    }
+
+    private static final class NoOpTask implements JLBHTask {
+        @Override
+        public void init(JLBH jlbh) {
+            // no-op
+        }
+
+        @Override
+        public void run(long startTimeNs) {
+            // no-op
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
@@ -1,0 +1,83 @@
+package net.openhft.chronicle.jlbh;
+
+import net.openhft.affinity.AffinityLock;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+public class JLBHOptionsTest {
+
+    @Test
+    public void shouldApplyAllConfigurationOptions() throws Exception {
+        JLBHOptions options = new JLBHOptions();
+        LatencyDistributor distributor = averageLatencyNS -> averageLatencyNS * 2;
+        Supplier<AffinityLock> customSupplier = () -> null;
+        JLBHTask task = new NoOpTask();
+
+        options.throughput(42)
+                .throughput(84, TimeUnit.MILLISECONDS)
+                .latencyDistributor(distributor)
+                .accountForCoordinatedOmission(false)
+                .recordJitterGreaterThanNs(12)
+                .recordOSJitter(false)
+                .warmUpIterations(123)
+                .runs(5)
+                .iterations(200)
+                .iterations(1_000_000L)
+                .jlbhTask(task)
+                .pauseAfterWarmupMS(77)
+                .skipFirstRun(true)
+                .jitterAffinity(true)
+                .acquireLock(customSupplier)
+                .timeout(9876L);
+
+        assertEquals(84, getField(options, "throughput", Integer.class).intValue());
+        assertEquals(TimeUnit.MILLISECONDS, getField(options, "throughputTimeUnit", TimeUnit.class));
+        assertSame(distributor, getField(options, "latencyDistributor", LatencyDistributor.class));
+        assertFalse(getField(options, "accountForCoordinatedOmission", Boolean.class));
+        assertEquals(12, getField(options, "recordJitterGreaterThanNs", Integer.class).intValue());
+        assertFalse(getField(options, "recordOSJitter", Boolean.class));
+        assertEquals(123, getField(options, "warmUpIterations", Integer.class).intValue());
+        assertEquals(5, getField(options, "runs", Integer.class).intValue());
+        assertEquals(1_000_000L, getField(options, "iterations", Long.class).longValue());
+        assertSame(task, getField(options, "jlbhTask", JLBHTask.class));
+        assertEquals(77, getField(options, "pauseAfterWarmupMS", Integer.class).intValue());
+        assertEquals(JLBHOptions.SKIP_FIRST_RUN.SKIP, getField(options, "skipFirstRun", JLBHOptions.SKIP_FIRST_RUN.class));
+        assertTrue(getField(options, "jitterAffinity", Boolean.class));
+        assertSame(customSupplier, getField(options, "acquireLock", Supplier.class));
+        assertEquals(9876L, getField(options, "timeout", Long.class).longValue());
+
+        String printable = options.toString();
+        assertTrue(printable.contains("runs=5"));
+        assertTrue(printable.contains("iterations=1000000"));
+        assertTrue(printable.contains("latencyDistributor="));
+    }
+
+    @Test
+    public void shouldRespectSkipFirstRunFalse() throws Exception {
+        JLBHOptions options = new JLBHOptions().skipFirstRun(false);
+        assertEquals(JLBHOptions.SKIP_FIRST_RUN.NO_SKIP, getField(options, "skipFirstRun", JLBHOptions.SKIP_FIRST_RUN.class));
+    }
+
+    private static <T> T getField(JLBHOptions options, String name, Class<T> type) throws Exception {
+        Field field = JLBHOptions.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return type.cast(field.get(options));
+    }
+
+    private static final class NoOpTask implements JLBHTask {
+        @Override
+        public void init(JLBH jlbh) {
+            // no-op
+        }
+
+        @Override
+        public void run(long startTimeNs) {
+            // no-op
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
@@ -1,0 +1,199 @@
+package net.openhft.chronicle.jlbh.util;
+
+import net.openhft.chronicle.jlbh.JLBHResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class JLBHResultSerializerTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final Duration P50 = Duration.ofNanos(100);
+    private static final Duration P90 = Duration.ofNanos(200);
+    private static final Duration P99 = Duration.ofNanos(300);
+    private static final Duration P999 = Duration.ofNanos(400);
+    private static final Duration WORST = Duration.ofNanos(600);
+
+    @Test
+    public void shouldWriteSelectedProbesWithoutOsJitter() throws IOException {
+        FakeRunResult endToEnd = new FakeRunResult(P50, P90, P99, P999, null, WORST);
+        FakeRunResult probe = new FakeRunResult(P50.multipliedBy(2), P90, P99, P999, null, WORST);
+        FakeResult result = new FakeResult(endToEnd, Map.of("TheProbe", probe), Optional.empty());
+
+        Path out = tmp.newFile("subset.csv").toPath();
+        JLBHResultSerializer.runResultToCSV(result, out.toString(), Collections.singletonList("TheProbe"), false);
+
+        List<String> lines = Files.readAllLines(out);
+        assertEquals(3, lines.size());
+        assertEquals(",50th p-le,90th p-le,99th p-le,999th p-le,9999th p-le,Worst,", lines.get(0));
+        assertEquals("endToEnd,100,200,300,400,,600,", lines.get(1));
+        assertEquals("TheProbe,200,200,300,400,,600,", lines.get(2));
+    }
+
+    @Test
+    public void shouldIncludeOsJitterAndAdditionalProbes() throws IOException {
+        FakeRunResult endToEnd = new FakeRunResult(P50, P90, P99, P999, Duration.ofNanos(500), WORST);
+        FakeRunResult probe = new FakeRunResult(P50, P90.multipliedBy(2), P99, P999, Duration.ofNanos(700), WORST);
+        FakeRunResult osJitter = new FakeRunResult(Duration.ofNanos(10), Duration.ofNanos(20), Duration.ofNanos(30),
+                Duration.ofNanos(40), Duration.ofNanos(50), Duration.ofNanos(60));
+
+        FakeResult result = new FakeResult(endToEnd, Map.of("Custom", probe), Optional.of(osJitter));
+
+        Path out = tmp.newFile("full.csv").toPath();
+        JLBHResultSerializer.runResultToCSV(result, out.toString(), Arrays.asList("Custom", "Missing"), true);
+
+        List<String> lines = Files.readAllLines(out);
+        assertEquals(4, lines.size());
+        assertEquals("endToEnd,100,200,300,400,500,600,", lines.get(1));
+        assertEquals("Custom,100,400,300,400,700,600,", lines.get(2));
+        assertEquals("OSJitter,10,20,30,40,50,60,", lines.get(3));
+    }
+
+    @Test
+    public void shouldDefaultToResultCsvInWorkingDirectory() throws IOException {
+        FakeRunResult runResult = new FakeRunResult(P50, P90, P99, P999, Duration.ofNanos(500), WORST);
+        FakeResult result = new FakeResult(runResult, Map.of("Probe", runResult), Optional.of(runResult));
+
+        Path output = Paths.get(JLBHResultSerializer.RESULT_CSV);
+        Files.deleteIfExists(output);
+        JLBHResultSerializer.runResultToCSV(result);
+        assertTrue(Files.exists(output));
+        List<String> lines = Files.readAllLines(output);
+        assertEquals(4, lines.size());
+        Files.deleteIfExists(output);
+    }
+
+    private static final class FakeResult implements JLBHResult {
+        private final ProbeResult endToEnd;
+        private final Map<String, ProbeResult> additionalProbes;
+        private final Optional<ProbeResult> osJitter;
+
+        private FakeResult(JLBHResult.RunResult endToEnd,
+                           Map<String, JLBHResult.RunResult> probes,
+                           Optional<JLBHResult.RunResult> osJitter) {
+            this.endToEnd = new FakeProbeResult(endToEnd);
+            Map<String, ProbeResult> probeResults = new HashMap<>();
+            for (Map.Entry<String, JLBHResult.RunResult> entry : probes.entrySet()) {
+                probeResults.put(entry.getKey(), new FakeProbeResult(entry.getValue()));
+            }
+            this.additionalProbes = probeResults;
+            this.osJitter = osJitter.map(FakeProbeResult::new);
+        }
+
+        @Override
+        public ProbeResult endToEnd() {
+            return endToEnd;
+        }
+
+        @Override
+        public Optional<ProbeResult> probe(String probeName) {
+            return Optional.ofNullable(additionalProbes.get(probeName));
+        }
+
+        @Override
+        public Set<String> probeNames() {
+            return additionalProbes.keySet();
+        }
+
+        @Override
+        public Optional<ProbeResult> osJitter() {
+            return osJitter;
+        }
+    }
+
+    private static final class FakeProbeResult implements JLBHResult.ProbeResult {
+        private final JLBHResult.RunResult runResult;
+
+        private FakeProbeResult(JLBHResult.RunResult runResult) {
+            this.runResult = runResult;
+        }
+
+        @Override
+        public JLBHResult.RunResult summaryOfLastRun() {
+            return runResult;
+        }
+
+        @Override
+        public List<JLBHResult.RunResult> eachRunSummary() {
+            return Collections.singletonList(runResult);
+        }
+    }
+
+    private static final class FakeRunResult implements JLBHResult.RunResult {
+        private final Duration p50;
+        private final Duration p90;
+        private final Duration p99;
+        private final Duration p999;
+        private final Duration p9999;
+        private final Duration worst;
+
+        private FakeRunResult(Duration p50,
+                              Duration p90,
+                              Duration p99,
+                              Duration p999,
+                              Duration p9999,
+                              Duration worst) {
+            this.p50 = p50;
+            this.p90 = p90;
+            this.p99 = p99;
+            this.p999 = p999;
+            this.p9999 = p9999;
+            this.worst = worst;
+        }
+
+        @Override
+        public Map<Percentile, Duration> percentiles() {
+            EnumMap<Percentile, Duration> map = new EnumMap<>(Percentile.class);
+            map.put(Percentile.PERCENTILE_50TH, p50);
+            map.put(Percentile.PERCENTILE_90TH, p90);
+            map.put(Percentile.PERCENTILE_99TH, p99);
+            map.put(Percentile.PERCENTILE_99_9TH, p999);
+            map.put(Percentile.WORST, worst);
+            if (p9999 != null) {
+                map.put(Percentile.PERCENTILE_99_99TH, p9999);
+            }
+            return map;
+        }
+
+        @Override
+        public Duration get50thPercentile() {
+            return p50;
+        }
+
+        @Override
+        public Duration get90thPercentile() {
+            return p90;
+        }
+
+        @Override
+        public Duration get99thPercentile() {
+            return p99;
+        }
+
+        @Override
+        public Duration get999thPercentile() {
+            return p999;
+        }
+
+        @Override
+        public Duration get9999thPercentile() {
+            return p9999;
+        }
+
+        @Override
+        public Duration getWorst() {
+            return worst;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
@@ -29,7 +29,7 @@ public class JLBHResultSerializerTest {
     public void shouldWriteSelectedProbesWithoutOsJitter() throws IOException {
         FakeRunResult endToEnd = new FakeRunResult(P50, P90, P99, P999, null, WORST);
         FakeRunResult probe = new FakeRunResult(P50.multipliedBy(2), P90, P99, P999, null, WORST);
-        FakeResult result = new FakeResult(endToEnd, Map.of("TheProbe", probe), Optional.empty());
+        FakeResult result = new FakeResult(endToEnd, Collections.singletonMap("TheProbe", probe), Optional.empty());
 
         Path out = tmp.newFile("subset.csv").toPath();
         JLBHResultSerializer.runResultToCSV(result, out.toString(), Collections.singletonList("TheProbe"), false);
@@ -48,7 +48,7 @@ public class JLBHResultSerializerTest {
         FakeRunResult osJitter = new FakeRunResult(Duration.ofNanos(10), Duration.ofNanos(20), Duration.ofNanos(30),
                 Duration.ofNanos(40), Duration.ofNanos(50), Duration.ofNanos(60));
 
-        FakeResult result = new FakeResult(endToEnd, Map.of("Custom", probe), Optional.of(osJitter));
+        FakeResult result = new FakeResult(endToEnd, Collections.singletonMap("Custom", probe), Optional.of(osJitter));
 
         Path out = tmp.newFile("full.csv").toPath();
         JLBHResultSerializer.runResultToCSV(result, out.toString(), Arrays.asList("Custom", "Missing"), true);
@@ -63,7 +63,7 @@ public class JLBHResultSerializerTest {
     @Test
     public void shouldDefaultToResultCsvInWorkingDirectory() throws IOException {
         FakeRunResult runResult = new FakeRunResult(P50, P90, P99, P999, Duration.ofNanos(500), WORST);
-        FakeResult result = new FakeResult(runResult, Map.of("Probe", runResult), Optional.of(runResult));
+        FakeResult result = new FakeResult(runResult, Collections.singletonMap("Probe", runResult), Optional.of(runResult));
 
         Path output = Paths.get(JLBHResultSerializer.RESULT_CSV);
         Files.deleteIfExists(output);


### PR DESCRIPTION
# Summary

  - add targeted JUnit coverage for JLBHResultSerializer, JLBHOptions, and key JLBH control paths (abort, timeout, formatting helpers), raising JaCoCo line coverage to ~89 %
  - integrate JaCoCo 0.8.14 into the Maven verify phase and document how to read the generated reports
  - refresh README and AsciiDoc guides to use ASCII-only symbols, add Nine-Box requirement tags, and make it explicit that OS jitter monitoring is enabled by default (cookbook, lifecycle, architecture,
    interpretation guide)
  - tidy the decision log bullet list and update licence references to LICENSE.adoc

  ## Testing

  - mvn -o verify
