### PR TITLE
Migrate JLBH tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,15 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
         <version>2026.0</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,6 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
@@ -59,13 +59,12 @@ class JLBHAdditionalCoverageTest {
      */
     @Test
     void shouldRejectEventLoopWhenCoordinatedOmissionDisabled() {
-        assertThrows(UnsupportedOperationException.class, () -> {
-            JLBHOptions options = newHarness(new NoOpTask())
-                    .accountForCoordinatedOmission(false)
-                    .recordOSJitter(false);
-            JLBH jlbh = new JLBH(options, silentPrintStream(), null);
-            jlbh.eventLoopHandler(null);
-        });
+        JLBHOptions options = newHarness(new NoOpTask())
+                .accountForCoordinatedOmission(false)
+                .recordOSJitter(false);
+        JLBH jlbh = new JLBH(options, silentPrintStream(), null);
+
+        assertThrows(UnsupportedOperationException.class, () -> jlbh.eventLoopHandler(null));
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
@@ -15,12 +15,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-public class JLBHAdditionalCoverageTest {
+class JLBHAdditionalCoverageTest {
     /**
      * Exercises {@link JLBH#abort()} to ensure the running harness can be stopped safely.
      */
     @Test
-    public void shouldAbortWhenRequested() {
+    void shouldAbortWhenRequested() {
         AbortOnRunTask task = new AbortOnRunTask();
         JLBHOptions options = newHarness(task)
                 .warmUpIterations(2)
@@ -38,7 +38,7 @@ public class JLBHAdditionalCoverageTest {
      * Verifies that configuring a timeout starts the watchdog thread without error.
      */
     @Test
-    public void shouldStartTimeoutCheckerWhenTimeoutConfigured() {
+    void shouldStartTimeoutCheckerWhenTimeoutConfigured() {
         CountingTask task = new CountingTask();
         JLBHOptions options = newHarness(task)
                 .warmUpIterations(1)
@@ -58,7 +58,7 @@ public class JLBHAdditionalCoverageTest {
      * coordinated omission compensation is disabled.
      */
     @Test
-    public void shouldRejectEventLoopWhenCoordinatedOmissionDisabled() {
+    void shouldRejectEventLoopWhenCoordinatedOmissionDisabled() {
         assertThrows(UnsupportedOperationException.class, () -> {
             JLBHOptions options = newHarness(new NoOpTask())
                     .accountForCoordinatedOmission(false)
@@ -72,7 +72,7 @@ public class JLBHAdditionalCoverageTest {
      * Covers helper methods that format percentile output.
      */
     @Test
-    public void shouldFormatRunSummaries() throws Exception {
+    void shouldFormatRunSummaries() throws Exception {
         JLBHOptions options = newHarness(new NoOpTask());
         JLBH jlbh = new JLBH(options, silentPrintStream(), null);
         Method addPr = JLBH.class.getDeclaredMethod("addPrToPrint", StringBuilder.class, String.class, int.class);

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
@@ -4,7 +4,6 @@
 package net.openhft.chronicle.jlbh;
 
 import net.openhft.chronicle.core.util.NanoSampler;
-import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -12,7 +11,9 @@ import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 public class JLBHAdditionalCoverageTest {
     /**
@@ -29,8 +30,8 @@ public class JLBHAdditionalCoverageTest {
 
         jlbh.start();
 
-        assertTrue("abort was not triggered", task.abortCount() > 0);
-        assertTrue("task should finish quickly after abort", task.totalRuns() < 5 * 20);
+        assertTrue(task.abortCount() > 0, "abort was not triggered");
+        assertTrue(task.totalRuns() < 5 * 20, "task should finish quickly after abort");
     }
 
     /**
@@ -49,20 +50,22 @@ public class JLBHAdditionalCoverageTest {
 
         jlbh.start();
 
-        assertTrue("samples should have been recorded", task.totalRuns() >= 1);
+        assertTrue(task.totalRuns() >= 1, "samples should have been recorded");
     }
 
     /**
      * Ensures {@link JLBH#eventLoopHandler(net.openhft.chronicle.core.threads.EventLoop)} rejects use when
      * coordinated omission compensation is disabled.
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectEventLoopWhenCoordinatedOmissionDisabled() {
-        JLBHOptions options = newHarness(new NoOpTask())
-                .accountForCoordinatedOmission(false)
-                .recordOSJitter(false);
-        JLBH jlbh = new JLBH(options, silentPrintStream(), null);
-        jlbh.eventLoopHandler(null);
+        assertThrows(UnsupportedOperationException.class, () -> {
+            JLBHOptions options = newHarness(new NoOpTask())
+                    .accountForCoordinatedOmission(false)
+                    .recordOSJitter(false);
+            JLBH jlbh = new JLBH(options, silentPrintStream(), null);
+            jlbh.eventLoopHandler(null);
+        });
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
@@ -4,10 +4,9 @@
 package net.openhft.chronicle.jlbh;
 
 import net.openhft.chronicle.core.OS;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -15,7 +14,8 @@ import java.io.PrintStream;
 import static net.openhft.chronicle.jlbh.JLBHDeterministicFixtures.*;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class JLBHIntegrationTest {
 
@@ -24,15 +24,15 @@ public class JLBHIntegrationTest {
     private ByteArrayOutputStream outContent;
     private ByteArrayOutputStream errContent;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         rememberOriginalStdErrOut();
-        Assume.assumeTrue(!OS.isMacOSX());
+        assumeTrue(!OS.isMacOSX());
         outContent = new ByteArrayOutputStream();
         errContent = new ByteArrayOutputStream();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         resetSystemOut();
     }

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
@@ -12,8 +12,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
 import static net.openhft.chronicle.jlbh.JLBHDeterministicFixtures.*;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
@@ -49,9 +47,9 @@ class JLBHIntegrationTest {
         // then
         String stdOut = outContent.toString();
         resetSystemOut();
-        assertThat(stdOut, containsString("OS Jitter"));
-        assertThat(stdOut, containsString("Warm up complete (500 iterations took "));
-        assertThat(stdOut, containsString("Run time: "));
+        assertTrue(stdOut.contains("OS Jitter"));
+        assertTrue(stdOut.contains("Warm up complete (500 iterations took "));
+        assertTrue(stdOut.contains("Run time: "));
         String actual = withoutNonDeterministicFields(stdOut);
         String expected = withoutNonDeterministicFields(predictableTaskExpectedResult());
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class JLBHIntegrationTest {
+class JLBHIntegrationTest {
 
     private PrintStream originalSystemOut;
     private PrintStream originalSystemErr;
@@ -25,7 +25,7 @@ public class JLBHIntegrationTest {
     private ByteArrayOutputStream errContent;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         rememberOriginalStdErrOut();
         assumeTrue(!OS.isMacOSX());
         outContent = new ByteArrayOutputStream();
@@ -33,12 +33,12 @@ public class JLBHIntegrationTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         resetSystemOut();
     }
 
     @Test
-    public void shouldMeasureLatency() {
+    void shouldMeasureLatency() {
         // given
         redirectSystemOut();
         final JLBH jlbh = new JLBH(options());

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
@@ -4,13 +4,13 @@
 package net.openhft.chronicle.jlbh;
 
 import net.openhft.affinity.AffinityLock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JLBHOptionsTest {
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
@@ -12,10 +12,10 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JLBHOptionsTest {
+class JLBHOptionsTest {
 
     @Test
-    public void shouldApplyAllConfigurationOptions() throws Exception {
+    void shouldApplyAllConfigurationOptions() throws Exception {
         JLBHOptions options = new JLBHOptions();
         LatencyDistributor distributor = averageLatencyNS -> averageLatencyNS * 2;
         Supplier<AffinityLock> customSupplier = () -> null;
@@ -61,7 +61,7 @@ public class JLBHOptionsTest {
     }
 
     @Test
-    public void shouldRespectSkipFirstRunFalse() throws Exception {
+    void shouldRespectSkipFirstRunFalse() throws Exception {
         JLBHOptions options = new JLBHOptions().skipFirstRun(false);
         assertEquals(JLBHOptions.SKIP_FIRST_RUN.NO_SKIP, getField(options, "skipFirstRun", JLBHOptions.SKIP_FIRST_RUN.class));
     }

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
@@ -9,10 +9,9 @@ import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.threads.MediumEventLoop;
 import net.openhft.chronicle.threads.Pauser;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -27,27 +26,26 @@ import static net.openhft.chronicle.jlbh.JLBHDeterministicFixtures.*;
 import static net.openhft.chronicle.jlbh.JLBHResult.RunResult.Percentile.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class JLBHTest {
     private EventLoop eventLoop;
 
-    public JLBHTest(boolean runFromEventLoop) {
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{{false}, {true}});
+    }
+
+    private void setUp(boolean runFromEventLoop) {
         if (runFromEventLoop) {
             eventLoop = new MediumEventLoop(null, "el", Pauser.busy(), true, null);
             eventLoop.start();
         }
     }
 
-    @Parameterized.Parameters(name = "event loop {0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{{false}, {true}});
-    }
-
-    @After
+    @AfterEach
     public void after() {
         Closeable.closeQuietly(eventLoop);
+        eventLoop = null;
     }
 
     private void start(JLBH jlbh) {
@@ -59,8 +57,10 @@ public class JLBHTest {
         }
     }
 
-    @Test
-    public void shouldWriteResultToTheOutputProvided() {
+    @ParameterizedTest(name = "event loop {0}")
+    @MethodSource("data")
+    public void shouldWriteResultToTheOutputProvided(boolean runFromEventLoop) {
+        setUp(runFromEventLoop);
 
         // given
         final OutputStream outputStream = new ByteArrayOutputStream();
@@ -75,33 +75,19 @@ public class JLBHTest {
         assertThat(result, containsString("Warm up complete (500 iterations took "));
         assertThat(result, containsString("Run time: "));
 
-        final String predictableTaskExpectedResult = predictableTaskExpectedResult();
-        System.out.println("predictableTaskExpectedResult = " + predictableTaskExpectedResult);
-        final String expected = withoutNonDeterministicFields(predictableTaskExpectedResult);
-        System.out.println("expected = " + expected);
+        final String expected = withoutNonDeterministicFields(predictableTaskExpectedResult());
         final String actual = withoutNonDeterministicFields(result);
-        System.out.println("actual = " + actual);
-
-        if (!expected.equals(actual)) {
-            System.err.println("expected");
-            expected.chars().limit(10).boxed().forEach(System.err::println);
-            System.err.println("actual");
-            actual.chars().limit(10).boxed().forEach(System.err::println);
-        }
-
-        // Disable for the moment. Reintroduce this assertion once the source of flakyness on Java 11 is figured out
-        // assertEquals(expected, actual);
-        if (!expected.equals(actual)) {
-            System.err.println("ERROR! There is an error here which is disabled at the moment! expected is not equal to actual");
-        }
+        assertEquals(expected, actual);
     }
 
-    @Test
+    @ParameterizedTest(name = "event loop {0}")
+    @MethodSource("data")
     /*
      * To understand the data, please go to JLBHDeterministicFixtures
      * and JLBHDeterministicFixtures::expectedOutput in particular
      */
-    public void shouldProvideResultData() {
+    public void shouldProvideResultData(boolean runFromEventLoop) {
+        setUp(runFromEventLoop);
 
         // given
         final JLBHResultConsumer resultConsumer = resultConsumer();
@@ -155,8 +141,10 @@ public class JLBHTest {
         assertEquals(probeALastRunSummary, summaryOfProbeAEachRun.get(2));
     }
 
-    @Test
-    public void shouldProvideResultDataEvenIfProbesDoNotProvideSameShapedData() {
+    @ParameterizedTest(name = "event loop {0}")
+    @MethodSource("data")
+    public void shouldProvideResultDataEvenIfProbesDoNotProvideSameShapedData(boolean runFromEventLoop) {
+        setUp(runFromEventLoop);
 
         // given
         final JLBHResultConsumer resultConsumer = resultConsumer();
@@ -174,8 +162,10 @@ public class JLBHTest {
         assertEquals(4, probeBLastRunSummary.percentiles().size());
     }
 
-    @Test
-    public void teamCityHelper() {
+    @ParameterizedTest(name = "event loop {0}")
+    @MethodSource("data")
+    public void teamCityHelper(boolean runFromEventLoop) {
+        setUp(runFromEventLoop);
 
         // given
         final JLBHResultConsumer resultConsumer = resultConsumer();
@@ -207,8 +197,11 @@ public class JLBHTest {
                 "##teamcity[buildStatisticValue key='prefix.B.1.0" + extra + "' value='0.100125']\n", baos.toString().replace("\r", ""));
     }
 
-    @Test
-    public void histogramSummariesAreCorrect() {
+    @ParameterizedTest(name = "event loop {0}")
+    @MethodSource("data")
+    public void histogramSummariesAreCorrect(boolean runFromEventLoop) {
+        setUp(runFromEventLoop);
+
         final JLBHResultConsumer resultConsumer = resultConsumer();
         JLBHOptions jlbhOptions = options().jlbhTask(new PredictableJLBHTaskDifferentShape()).iterations(ITERATIONS * 2);
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -228,8 +221,10 @@ public class JLBHTest {
                 "worst:           0.10         0.10         0.10         0.00"));
     }
 
-    @Test
-    public void shouldCallAllLifecycleMethods() {
+    @ParameterizedTest(name = "event loop {0}")
+    @MethodSource("data")
+    public void shouldCallAllLifecycleMethods(boolean runFromEventLoop) {
+        setUp(runFromEventLoop);
 
         AtomicInteger initCount = new AtomicInteger(0);
         AtomicInteger runCount = new AtomicInteger(0);

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JLBHTest {
+class JLBHTest {
     private EventLoop eventLoop;
 
     public static Collection<Object[]> data() {
@@ -43,7 +43,7 @@ public class JLBHTest {
     }
 
     @AfterEach
-    public void after() {
+    void after() {
         Closeable.closeQuietly(eventLoop);
         eventLoop = null;
     }
@@ -59,7 +59,7 @@ public class JLBHTest {
 
     @ParameterizedTest(name = "event loop {0}")
     @MethodSource("data")
-    public void shouldWriteResultToTheOutputProvided(boolean runFromEventLoop) {
+    void shouldWriteResultToTheOutputProvided(boolean runFromEventLoop) {
         setUp(runFromEventLoop);
 
         // given
@@ -82,11 +82,11 @@ public class JLBHTest {
 
     @ParameterizedTest(name = "event loop {0}")
     @MethodSource("data")
-    /*
-     * To understand the data, please go to JLBHDeterministicFixtures
-     * and JLBHDeterministicFixtures::expectedOutput in particular
-     */
-    public void shouldProvideResultData(boolean runFromEventLoop) {
+        /*
+         * To understand the data, please go to JLBHDeterministicFixtures
+         * and JLBHDeterministicFixtures::expectedOutput in particular
+         */
+    void shouldProvideResultData(boolean runFromEventLoop) {
         setUp(runFromEventLoop);
 
         // given
@@ -143,7 +143,7 @@ public class JLBHTest {
 
     @ParameterizedTest(name = "event loop {0}")
     @MethodSource("data")
-    public void shouldProvideResultDataEvenIfProbesDoNotProvideSameShapedData(boolean runFromEventLoop) {
+    void shouldProvideResultDataEvenIfProbesDoNotProvideSameShapedData(boolean runFromEventLoop) {
         setUp(runFromEventLoop);
 
         // given
@@ -164,7 +164,7 @@ public class JLBHTest {
 
     @ParameterizedTest(name = "event loop {0}")
     @MethodSource("data")
-    public void teamCityHelper(boolean runFromEventLoop) {
+    void teamCityHelper(boolean runFromEventLoop) {
         setUp(runFromEventLoop);
 
         // given
@@ -199,7 +199,7 @@ public class JLBHTest {
 
     @ParameterizedTest(name = "event loop {0}")
     @MethodSource("data")
-    public void histogramSummariesAreCorrect(boolean runFromEventLoop) {
+    void histogramSummariesAreCorrect(boolean runFromEventLoop) {
         setUp(runFromEventLoop);
 
         final JLBHResultConsumer resultConsumer = resultConsumer();
@@ -214,16 +214,16 @@ public class JLBHTest {
         System.out.println(baos);
         assertTrue(baos.toString().replace("\r", "").contains(
                 "-------------------------------- SUMMARY (B) us ----------------------------------------------------\n" +
-                "Percentile   run1         run2         run3      % Variation\n" +
-                "50.0:            0.10         0.10         0.10         0.00\n" +
-                "90.0:            0.10         0.10         0.10         0.00\n" +
-                "99.0:            0.10         0.10         0.10         0.00\n" +
-                "worst:           0.10         0.10         0.10         0.00"));
+                        "Percentile   run1         run2         run3      % Variation\n" +
+                        "50.0:            0.10         0.10         0.10         0.00\n" +
+                        "90.0:            0.10         0.10         0.10         0.00\n" +
+                        "99.0:            0.10         0.10         0.10         0.00\n" +
+                        "worst:           0.10         0.10         0.10         0.00"));
     }
 
     @ParameterizedTest(name = "event loop {0}")
     @MethodSource("data")
-    public void shouldCallAllLifecycleMethods(boolean runFromEventLoop) {
+    void shouldCallAllLifecycleMethods(boolean runFromEventLoop) {
         setUp(runFromEventLoop);
 
         AtomicInteger initCount = new AtomicInteger(0);

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
@@ -24,8 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.openhft.chronicle.jlbh.JLBHDeterministicFixtures.*;
 import static net.openhft.chronicle.jlbh.JLBHResult.RunResult.Percentile.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class JLBHTest {
@@ -71,9 +69,9 @@ class JLBHTest {
 
         // then
         String result = outputStream.toString().replace("\r", "");
-        assertThat(result, containsString("OS Jitter"));
-        assertThat(result, containsString("Warm up complete (500 iterations took "));
-        assertThat(result, containsString("Run time: "));
+        assertTrue(result.contains("OS Jitter"));
+        assertTrue(result.contains("Warm up complete (500 iterations took "));
+        assertTrue(result.contains("Run time: "));
 
         final String expected = withoutNonDeterministicFields(predictableTaskExpectedResult());
         final String actual = withoutNonDeterministicFields(result);
@@ -112,8 +110,8 @@ class JLBHTest {
 
         final List<JLBHResult.RunResult> summaryOfEachRun = resultConsumer.get().endToEnd().eachRunSummary();
         assertEquals(3, summaryOfEachRun.size());
-        assertThat(summaryOfEachRun.get(0), not(equalTo(lastRunSummary)));
-        assertThat(summaryOfEachRun.get(1), not(equalTo(lastRunSummary)));
+        assertNotEquals(lastRunSummary, summaryOfEachRun.get(0));
+        assertNotEquals(lastRunSummary, summaryOfEachRun.get(1));
         assertEquals(lastRunSummary, summaryOfEachRun.get(2));
 
         assertTrue(resultConsumer.get().probe("A").isPresent());
@@ -136,8 +134,8 @@ class JLBHTest {
 
         final List<JLBHResult.RunResult> summaryOfProbeAEachRun = resultConsumer.get().probe("A").get().eachRunSummary();
         assertEquals(3, summaryOfProbeAEachRun.size());
-        assertThat(summaryOfProbeAEachRun.get(0), not(equalTo(probeALastRunSummary)));
-        assertThat(summaryOfProbeAEachRun.get(1), not(equalTo(probeALastRunSummary)));
+        assertNotEquals(probeALastRunSummary, summaryOfProbeAEachRun.get(0));
+        assertNotEquals(probeALastRunSummary, summaryOfProbeAEachRun.get(1));
         assertEquals(probeALastRunSummary, summaryOfProbeAEachRun.get(2));
     }
 

--- a/src/test/java/net/openhft/chronicle/jlbh/LatencyDistributorsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/LatencyDistributorsTest.java
@@ -12,11 +12,11 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class LatencyDistributorsTest {
+class LatencyDistributorsTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("data")
-    public void averageOk(LatencyDistributor ld) {
+    void averageOk(LatencyDistributor ld) {
         long base = 10_000; // e.g. 100_000/s
         long sum = 0;
         final int count = 100_000;

--- a/src/test/java/net/openhft/chronicle/jlbh/LatencyDistributorsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/LatencyDistributorsTest.java
@@ -3,39 +3,31 @@
  */
 package net.openhft.chronicle.jlbh;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class LatencyDistributorsTest {
 
-    private final LatencyDistributor ld;
-
-    public LatencyDistributorsTest(LatencyDistributor ld) {
-        this.ld = ld;
-    }
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.stream(LatencyDistributors.values())
-                .map(x -> new Object[]{x})
-                .collect(Collectors.toList());
-    }
-
-    @Test
-    public void averageOk() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void averageOk(LatencyDistributor ld) {
         long base = 10_000; // e.g. 100_000/s
         long sum = 0;
         final int count = 100_000;
         for (int i = 0; i < count; i++)
             sum += ld.apply(base);
         assertEquals(count * base, sum, sum / 50.0);
+    }
+
+    public static Collection<Object[]> data() {
+        return Arrays.stream(LatencyDistributors.values())
+                .map(x -> new Object[]{x})
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/net/openhft/chronicle/jlbh/PercentileSummaryTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/PercentileSummaryTest.java
@@ -11,12 +11,12 @@ import java.util.List;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PercentileSummaryTest {
+class PercentileSummaryTest {
 
     private static final double DELTA = 0.00001;
 
     @Test
-    public void testThatMissingPercentilesAreOmitted() {
+    void testThatMissingPercentilesAreOmitted() {
         List<double[]> percentileSummaries = new ArrayList<>();
         for (int i = 2; i < 10; i++) {
             double[] summary = new double[i];
@@ -43,7 +43,7 @@ public class PercentileSummaryTest {
     }
 
     @Test
-    public void testThatWorstIsRenderedCorrectly() {
+    void testThatWorstIsRenderedCorrectly() {
         List<double[]> percentileSummaries = new ArrayList<>();
         for (int i = 2; i < 10; i++) {
             double[] summary = new double[i];
@@ -68,7 +68,7 @@ public class PercentileSummaryTest {
     }
 
     @Test
-    public void testThatVarianceIsCalculatedCorrectly() {
+    void testThatVarianceIsCalculatedCorrectly() {
         List<double[]> percentileSummaries = new ArrayList<>();
         for (int i = 2; i < 10; i++) {
             double[] summary = new double[i];
@@ -82,15 +82,15 @@ public class PercentileSummaryTest {
         final PercentileSummary percentileSummary = new PercentileSummary(false, percentileSummaries, percentiles);
         percentileSummary.printSummary();
 
-        assertEquals((0.009 - 0.002) / (0.009 + 0.002 /2) * 100, percentileSummary.calculateVariance(0), DELTA);
-        assertEquals((0.009 - 0.003) / (0.009 + 0.003 /2) * 100, percentileSummary.calculateVariance(1), DELTA);
-        assertEquals((0.009 - 0.004) / (0.009 + 0.004 /2) * 100, percentileSummary.calculateVariance(2), DELTA);
-        assertEquals((0.009 - 0.005) / (0.009 + 0.005 /2) * 100, percentileSummary.calculateVariance(3), DELTA);
+        assertEquals((0.009 - 0.002) / (0.009 + 0.002 / 2) * 100, percentileSummary.calculateVariance(0), DELTA);
+        assertEquals((0.009 - 0.003) / (0.009 + 0.003 / 2) * 100, percentileSummary.calculateVariance(1), DELTA);
+        assertEquals((0.009 - 0.004) / (0.009 + 0.004 / 2) * 100, percentileSummary.calculateVariance(2), DELTA);
+        assertEquals((0.009 - 0.005) / (0.009 + 0.005 / 2) * 100, percentileSummary.calculateVariance(3), DELTA);
         assertEquals(0, percentileSummary.calculateVariance(percentiles.length - 2), DELTA);
     }
 
     @Test
-    public void testVarianceSkipFirst() {
+    void testVarianceSkipFirst() {
         List<double[]> percentileSummaries = new ArrayList<>();
         for (int i = 2; i < 10; i++) {
             double[] summary = new double[i];
@@ -105,13 +105,13 @@ public class PercentileSummaryTest {
         percentileSummary.printSummary();
 
         // 50th percentile
-        assertEquals((0.009 - 0.003) / (0.009 + 0.003 /2) * 100, percentileSummary.calculateVariance(0), DELTA);
+        assertEquals((0.009 - 0.003) / (0.009 + 0.003 / 2) * 100, percentileSummary.calculateVariance(0), DELTA);
         // 90th has no value in the first run, so nothing to skip?
-        assertEquals((0.009 - 0.003) / (0.009 + 0.003 /2) * 100, percentileSummary.calculateVariance(1), DELTA);
+        assertEquals((0.009 - 0.003) / (0.009 + 0.003 / 2) * 100, percentileSummary.calculateVariance(1), DELTA);
     }
 
     @Test
-    public void testForEachRow() {
+    void testForEachRow() {
         List<double[]> percentileSummaries = new ArrayList<>();
         double[] percentiles = new double[]{0.5, 0.9, 0.97, 1.0};
         for (int i = 2; i < percentiles.length; i++) {
@@ -130,10 +130,10 @@ public class PercentileSummaryTest {
             receivedValues.add(values);
             receivedVariances.add(variance);
         });
-        assertArrayEquals(new Double[] {0.5, 0.9, 1.0}, receivedPercentiles.toArray(new Double[] {}));
-        assertArrayEquals(new double[] {0.002, 0.003}, receivedValues.get(0), DELTA);
-        assertArrayEquals(new double[] {POSITIVE_INFINITY, 0.003}, receivedValues.get(1), DELTA);
-        assertArrayEquals(new double[] {0.002, 0.003}, receivedValues.get(2), DELTA);
-        assertArrayEquals(new Double[] {25.0, 0.0, 25.0}, receivedVariances.toArray(new Double[] {}));
+        assertArrayEquals(new Double[]{0.5, 0.9, 1.0}, receivedPercentiles.toArray(new Double[]{}));
+        assertArrayEquals(new double[]{0.002, 0.003}, receivedValues.get(0), DELTA);
+        assertArrayEquals(new double[]{POSITIVE_INFINITY, 0.003}, receivedValues.get(1), DELTA);
+        assertArrayEquals(new double[]{0.002, 0.003}, receivedValues.get(2), DELTA);
+        assertArrayEquals(new Double[]{25.0, 0.0, 25.0}, receivedVariances.toArray(new Double[]{}));
     }
 }

--- a/src/test/java/net/openhft/chronicle/jlbh/PercentileSummaryTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/PercentileSummaryTest.java
@@ -3,14 +3,13 @@
  */
 package net.openhft.chronicle.jlbh;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.lang.Double.POSITIVE_INFINITY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PercentileSummaryTest {
 

--- a/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
@@ -17,7 +17,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JLBHResultSerializerTest {
+class JLBHResultSerializerTest {
 
     @TempDir
     File tmp;
@@ -29,7 +29,7 @@ public class JLBHResultSerializerTest {
     private static final Duration WORST = Duration.ofNanos(600);
 
     @Test
-    public void shouldWriteSelectedProbesWithoutOsJitter() throws IOException {
+    void shouldWriteSelectedProbesWithoutOsJitter() throws IOException {
         FakeRunResult endToEnd = new FakeRunResult(P50, P90, P99, P999, null, WORST);
         FakeRunResult probe = new FakeRunResult(P50.multipliedBy(2), P90, P99, P999, null, WORST);
         FakeResult result = new FakeResult(endToEnd, Collections.singletonMap("TheProbe", probe), Optional.empty());
@@ -47,7 +47,7 @@ public class JLBHResultSerializerTest {
     }
 
     @Test
-    public void shouldIncludeOsJitterAndAdditionalProbes() throws IOException {
+    void shouldIncludeOsJitterAndAdditionalProbes() throws IOException {
         FakeRunResult endToEnd = new FakeRunResult(P50, P90, P99, P999, Duration.ofNanos(500), WORST);
         FakeRunResult probe = new FakeRunResult(P50, P90.multipliedBy(2), P99, P999, Duration.ofNanos(700), WORST);
         FakeRunResult osJitter = new FakeRunResult(Duration.ofNanos(10), Duration.ofNanos(20), Duration.ofNanos(30),
@@ -68,7 +68,7 @@ public class JLBHResultSerializerTest {
     }
 
     @Test
-    public void shouldDefaultToResultCsvInWorkingDirectory() throws IOException {
+    void shouldDefaultToResultCsvInWorkingDirectory() throws IOException {
         FakeRunResult runResult = new FakeRunResult(P50, P90, P99, P999, Duration.ofNanos(500), WORST);
         FakeResult result = new FakeResult(runResult, Collections.singletonMap("Probe", runResult), Optional.of(runResult));
 

--- a/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
@@ -4,10 +4,10 @@
 package net.openhft.chronicle.jlbh.util;
 
 import net.openhft.chronicle.jlbh.JLBHResult;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,12 +15,12 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JLBHResultSerializerTest {
 
-    @Rule
-    public final TemporaryFolder tmp = new TemporaryFolder();
+    @TempDir
+    File tmp;
 
     private static final Duration P50 = Duration.ofNanos(100);
     private static final Duration P90 = Duration.ofNanos(200);
@@ -34,7 +34,9 @@ public class JLBHResultSerializerTest {
         FakeRunResult probe = new FakeRunResult(P50.multipliedBy(2), P90, P99, P999, null, WORST);
         FakeResult result = new FakeResult(endToEnd, Collections.singletonMap("TheProbe", probe), Optional.empty());
 
-        Path out = tmp.newFile("subset.csv").toPath();
+        File subsetFile = new File(tmp, "subset.csv");
+        subsetFile.createNewFile();
+        Path out = subsetFile.toPath();
         JLBHResultSerializer.runResultToCSV(result, out.toString(), Collections.singletonList("TheProbe"), false);
 
         List<String> lines = Files.readAllLines(out);
@@ -53,7 +55,9 @@ public class JLBHResultSerializerTest {
 
         FakeResult result = new FakeResult(endToEnd, Collections.singletonMap("Custom", probe), Optional.of(osJitter));
 
-        Path out = tmp.newFile("full.csv").toPath();
+        File fullFile = new File(tmp, "full.csv");
+        fullFile.createNewFile();
+        Path out = fullFile.toPath();
         JLBHResultSerializer.runResultToCSV(result, out.toString(), Arrays.asList("Custom", "Missing"), true);
 
         List<String> lines = Files.readAllLines(out);


### PR DESCRIPTION
## Summary
Migrate the remaining JLBH tests and assertions to Jupiter and remove the leftover JUnit 4/Vintage dependency path.

## Included Work
- Refine JUnit 5 migration assertions
- Migrate remaining JLBH tests to Jupiter

## Changed Areas
- `pom.xml`
- `src/test`

## Notes
- Compared against `develop` after refreshing `origin/develop` on 2026-03-24.
- Full repository test suites were not rerun during this bulk PR creation pass.
