### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,5 +1,5 @@
 
-== Copyright 2016-2025 chronicle.software
+== Copyright 2016-2026 chronicle.software
 
 Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 #
 
 # Jekyll theme configuration for documentation site

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     </parent>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <jacoco.line.coverage>0.883</jacoco.line.coverage>
         <jacoco.branch.coverage>0.786</jacoco.branch.coverage>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/src/main/java/net/openhft/chronicle/jlbh/ImmutableJLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ImmutableJLBHResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/ImmutableProbeResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ImmutableProbeResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/ImmutableRunResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ImmutableRunResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHOptions.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHResultConsumer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHResultConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHTask.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributor.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributors.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/LatencyDistributors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/PercentileSummary.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/PercentileSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/TeamCityHelper.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/TeamCityHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/ThreadSafeJLBHResultConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/package-info.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides the classes for the Java Latency Benchmark Harness.

--- a/src/main/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh.util;
 

--- a/src/main/java/net/openhft/chronicle/jlbh/util/package-info.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Miscellaneous utilities used by the benchmark harness.

--- a/src/main/java/net/openhft/chronicle/package-info.java
+++ b/src/main/java/net/openhft/chronicle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * The {@code net.openhft.chronicle} packages contain the Chronicle stack of

--- a/src/main/java/net/openhft/package-info.java
+++ b/src/main/java/net/openhft/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Root of the OpenHFT namespace.

--- a/src/test/java/net/openhft/chronicle/jlbh/ExampleJLBHMain.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/ExampleJLBHMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHAdditionalCoverageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHDeterministicFixtures.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHDeterministicFixtures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/LatencyDistributorsTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/LatencyDistributorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/NothingBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/NothingBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/PercentileSummaryTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/PercentileSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/SimpleBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/SimpleBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/SimpleOSJitterBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/SimpleOSJitterBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/SimpleResultSerializerBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/SimpleResultSerializerBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh;
 

--- a/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.jlbh.util;
 


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)