### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -5,7 +5,7 @@ Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ toc::[]
 
 Java Latency Benchmark Harness is a tool that allows you to benchmark your code running in context, rather than in a microbenchmark.
 See <<further-reading,Further Reading>> for a series of articles introducing JLBH.
-An excellent introduction can be found in http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[this series of articles.]
+An excellent introduction can be found in https://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[this series of articles.]
 link:src/main/adoc/project-requirements.adoc[The requirements document] contains detailed feature descriptions.
 
 For terminology used throughout the project, see link:src/main/adoc/project-requirements.adoc#_7-glossary[the Glossary (section 7)].
@@ -171,7 +171,7 @@ The following table summarises the main non-functional quality attributes derive
 [[further-reading]]
 == Further Reading
 
-http://www.rationaljava.com/2016/04/jlbh-introducing-java-latency.html[Introducing JLBH]
+https://www.rationaljava.com/2016/04/jlbh-introducing-java-latency.html[Introducing JLBH]
 
 * What is JLBH
 * What was the motivation for JLBH
@@ -192,7 +192,7 @@ Percentile   run1         run2         run3      % Variation
 worst:          12.56        12.56        10.61        10.93
 ----
 
-http://www.rationaljava.com/2016/04/jlbh-examples-1-why-code-should-be.html[Why Code Should be Benchmarked in Context]
+https://www.rationaljava.com/2016/04/jlbh-examples-1-why-code-should-be.html[Why Code Should be Benchmarked in Context]
 
 * A side by side example using JMH and JLBH for Date serialisation
 * Measuring Date serialisation in a microbenchmark
@@ -202,13 +202,13 @@ http://www.rationaljava.com/2016/04/jlbh-examples-1-why-code-should-be.html[Why 
 
 Co-ordinated omission occurs when latency measurements ignore the time requests wait to be serviced, leading to unrealistically low results.
 
-http://www.rationaljava.com/2016/04/jlbh-examples-2-accounting-for.html[Accounting for Coordinated Omission]
+https://www.rationaljava.com/2016/04/jlbh-examples-2-accounting-for.html[Accounting for Coordinated Omission]
 
 * Running JLBH with and without accounting for coordinated omission
 * An example illustrating the numerical impact of coordinated omission
 * A discussion about flow control
 
-http://www.rationaljava.com/2016/04/jlbh-examples-3-affects-of-throughput.html[The Affects of Throughput on Latency]
+https://www.rationaljava.com/2016/04/jlbh-examples-3-affects-of-throughput.html[The Affects of Throughput on Latency]
 Note: the blog deliberately uses "Affects" in the title while describing the effects of throughput on latency.
 
 * A discussion about the effects of throughput on latency
@@ -217,7 +217,7 @@ Note: the blog deliberately uses "Affects" in the title while describing the eff
 * Watching the effect of increasing throughput on latency
 * Understanding that you have to drop throughput to achieve good latencies at high percentiles.
 
-http://www.rationaljava.com/2016/04/jlbh-examples-4-benchmarking-quickfix.html[Benchmarking QuickFix vs ChronicleFix]
+https://www.rationaljava.com/2016/04/jlbh-examples-4-benchmarking-quickfix.html[Benchmarking QuickFix vs ChronicleFix]
 
 * Using JLBH to benchmark QuickFIX
 * Observing how QuickFix latencies degrade through the percentiles

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -34,7 +34,7 @@ The harness targets _low-latency_ Java applications (trading systems, micro-serv
 
 * Upstream repository: https://github.com/OpenHFT/JLBH[GitHub - OpenHFT/JLBH]
 * API reference: https://javadoc.io/doc/net.openhft/chronicle-core/latest/net/openhft/chronicle/core/jlbh/JLBH.html[Javadoc]
-* Tutorial series: http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[RationalJava blog series]
+* Tutorial series: https://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html[RationalJava blog series]
 * Discussion of _co-ordinated omission_: https://groups.google.com/g/mechanical-sympathy/c/icNZJejUHfE[m.s. thread]
 * Chronicle blog post on JLBH in event loops: https://vanilla-java.github.io/2016/04/02/Microservices-in-the-Chronicle-World-Part-5.html[Vanilla-Java article]
 
@@ -193,6 +193,6 @@ public class NothingBenchmark implements JLBHTask {
 
 * JLBH originated within the Chronicle Software open-source stack and is actively maintained. See https://github.com/OpenHFT/JLBH.
 * The API reference highlights the focus on _co-ordinated omission_ and event-loop support. See https://www.javadoc.io/doc/net.openhft/chronicle-core/latest/net/openhft/chronicle/jlbh/JLBH.html.
-* A multi-part blog series gives practical guidance on designing realistic latency tests. See http://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html.
+* A multi-part blog series gives practical guidance on designing realistic latency tests. See https://www.rationaljava.com/2016/04/a-series-of-posts-on-jlbh-java-latency.html.
 * Vanilla-Java's micro-services article demonstrates embedding JLBH in an event-driven architecture. See https://vanilla-java.github.io/2016/04/02/Microservices-in-the-Chronicle-World-Part-5.html.
 * Original discussion of co-ordinated omission by Gil Tene motivates JLBH's default settings. See https://groups.google.com/g/mechanical-sympathy/c/icNZJejUHfE.


### PR DESCRIPTION
## Summary
- Upgrades `http://` to `https://` in documentation files (.adoc, .md, LICENSE, NOTICE, AGENTS) and Java comment lines.
- Skips XML namespace identifiers (`xmlns=`, `xsi:schemaLocation=`) and non-comment Java source where a URL might be a literal value.
- Mechanical change, no code behaviour affected.

## Test plan
- [ ] Visual diff - only protocol `http` -> `https` changes.
- [ ] Spot-check a few upgraded links still resolve.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)