### PR TITLE
docs: repair JLBH version and API documentation links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ Chronicle Software
 :icons: font
 
 image:https://img.shields.io/maven-central/v/net.openhft/jlbh.svg[caption="",link=https://central.sonatype.com/artifact/net.openhft/jlbh]
-image:https://javadoc.io/badge2/net.openhft/JLBH/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-wire/latest/index.html"]
+image:https://javadoc.io/badge2/net.openhft/jlbh/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/jlbh/latest/index.html"]
 //image:https://javadoc-badge.appspot.com/net.openhft/jlbh.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/jlbh]
 image:https://img.shields.io/github/license/OpenHFT/JLBH[GitHub]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Chronicle Software
 :toclevels: 2
 :icons: font
 
-image:https://maven-badges.herokuapp.com/maven-central/net.openhft/jlbh/badge.svg[caption="",link=https://maven-badges.herokuapp.com/maven-central/net.openhft/jlbh]
+image:https://img.shields.io/maven-central/v/net.openhft/jlbh.svg[caption="",link=https://central.sonatype.com/artifact/net.openhft/jlbh]
 image:https://javadoc.io/badge2/net.openhft/JLBH/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-wire/latest/index.html"]
 //image:https://javadoc-badge.appspot.com/net.openhft/jlbh.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/jlbh]
 image:https://img.shields.io/github/license/OpenHFT/JLBH[GitHub]


### PR DESCRIPTION
The README API badge points to Chronicle Wire and uses uppercase `JLBH` in its image coordinate. Use lowercase `jlbh` for both the image and [JLBH Javadoc destination](https://www.javadoc.io/doc/net.openhft/jlbh/latest/index.html), incorporating #186.

Also replace the version badge with [Shields' Maven Central API](https://shields.io/badges/maven-central-version) and link it to [net.openhft:jlbh](https://central.sonatype.com/artifact/net.openhft/jlbh). [The badge service's migration notice](https://github.com/softwaremill/maven-badges#readme) deprecated the Heroku URL and limited its availability to the end of 2025.

Validation on 9 September 2026: rendered the full README with Asciidoctor 2.0.20 without warnings; checked the rendered badge's destination and the POM coordinate. The badge SVG returned HTTP 200 with a version label, and the artifact page returned HTTP 200 for the intended artifact. `git diff --check` passes. The Javadoc badge and destination also returned HTTP 200 for `jlbh`, and the rendered HTML points to the correct API. The diff is two README lines; Java tests were not rerun for these documentation edits.
