### PR TITLE
docs: fix common typos

### DIFF
--- a/src/main/java/net/openhft/chronicle/jlbh/JLBHTask.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBHTask.java
@@ -13,7 +13,7 @@ public interface JLBHTask {
      *
      * @param jlbh A reference to the JLBH which is needed so that {@code jlbh.sample()}
      *             can be invoked when the benchmark is complete. It can also be used to
-     *             create more probes into the benchamrk.
+     *             create more probes into the benchmark.
      */
     void init(JLBH jlbh);
 


### PR DESCRIPTION
## Summary
Typo fixes covering: `locaiton`, `receieved`, `visibe`, `receipient`, `Signtaure`, `signatire`, `extenstions`, `diabled`, `overriden`, `sl4j`, `andd`, `resuable`, `endian-independant`, `benchamrk`, `by used`/`will replaced`, and the `CPI` -> `CPU` slip in AffinityLock javadoc.

Doc-only - no behaviour changes.

## Test plan
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)