### PR TITLE
docs: replace above-U+00FF characters with 8-bit equivalents

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -162,7 +162,7 @@ The following table summarises the main non-functional quality attributes derive
 
 | Performance | Overhead per sample must remain below 100 ns when no additional probes are active. Histogram generation must support >=200 M iterations without heap pressure.
 | Reliability | Harness must abort gracefully on interruptions or sample time-outs, and immutable result objects ensure thread-safe publication.
-| Usability | Fluent builder API with sensible defaults yields a runnable benchmark in ≤10 LOC. ASCII table outputs are human-readable and CI-friendly.
+| Usability | Fluent builder API with sensible defaults yields a runnable benchmark in <=10 LOC. ASCII table outputs are human-readable and CI-friendly.
 | Portability | Pure-Java codebase with runtime-detected JDK optimisations; no native compilation.
 | Maintainability | >=80 % unit-test coverage and adherence to Chronicle coding standards validated by SonarCloud.
 | Security | No executable deserialisation; harness operates in-process. Users remain responsible for securing benchmarked code.

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -144,7 +144,7 @@ Post-run, results can be persisted for offline analysis (`result.csv` by default
 * Immutable result objects ensure thread-safe publication to external consumers.
 
 === 5.3 NF-UX-001 Usability
-* Fluent builder API; sensible defaults provide a runnable benchmark in ≤10 LOC.
+* Fluent builder API; sensible defaults provide a runnable benchmark in <=10 LOC.
 * ASCII table outputs are human-readable and CI-friendly.
 
 === 5.4 NF-O-001 Portability

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
@@ -795,12 +795,12 @@ public class JLBH implements NanoSampler {
          * scheduling iterations and waiting for a run to finish.
          * </p>
          * <ul>
-         *     <li><b>Scheduling iterations</b> – when not waiting for a run to
+         *     <li><b>Scheduling iterations</b> - when not waiting for a run to
          *     finish the handler invokes the {@link JLBHTask} at
          *     {@code nextInvokeTime}. After each invocation counters are
          *     updated and once all iterations have been scheduled the handler
          *     switches to the waiting state.</li>
-         *     <li><b>Waiting for completion</b> – when all iterations of the
+         *     <li><b>Waiting for completion</b> - when all iterations of the
          *     current run are scheduled the handler waits until the end to end
          *     histogram contains {@code jlbhOptions.iterations} samples. The
          *     run is then finalised and either the next run is started or, if


### PR DESCRIPTION
## Summary
Documentation is expected to stay within 8-bit (1-255) so characters outside that range are folded to their closest Latin-1/ASCII forms:

| Before | After |
|--------|-------|
| en-dash, non-breaking hyphen, figure dash | `-` |
| em-dash, horizontal bar | `--` |
| ellipsis | `...` |
| zero-width space / joiners / direction marks | *removed* |
| smart single quotes `'` `'` | `'` |
| smart double quotes `"` `"` | `"` |
| `<=`, `>=` | `<=`, `>=` |

Latin-1 characters (micro sign, non-breaking space, etc.) are left alone.

## Test plan
- [ ] Rendered output still reads naturally.
- [ ] No code semantics affected (text-only files).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)