### PR TITLE
docs: fix JLBH javadoc badge artifact

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ Chronicle Software
 :icons: font
 
 image:https://maven-badges.herokuapp.com/maven-central/net.openhft/jlbh/badge.svg[caption="",link=https://maven-badges.herokuapp.com/maven-central/net.openhft/jlbh]
-image:https://javadoc.io/badge2/net.openhft/JLBH/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-wire/latest/index.html"]
+image:https://javadoc.io/badge2/net.openhft/jlbh/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/jlbh/latest/index.html"]
 //image:https://javadoc-badge.appspot.com/net.openhft/jlbh.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/jlbh]
 image:https://img.shields.io/github/license/OpenHFT/JLBH[GitHub]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]


### PR DESCRIPTION
Superseded by #181, which now includes both corrections: lowercase jlbh in the Javadoc badge coordinate and a destination pointing to JLBH's API instead of Chronicle Wire. The combined PR repairs version and API navigation together.
