### PR TITLE
Fix constructor safety and UTF-8 CSV error reporting

### DIFF
--- a/src/main/adoc/benchmark-lifecycle.adoc
+++ b/src/main/adoc/benchmark-lifecycle.adoc
@@ -25,6 +25,12 @@ This initial phase prepares the benchmark environment:
 * **OS Jitter Monitoring**: Jitter tracking is enabled by default (`recordOSJitter` defaults to true); unless disabled via `recordOSJitter(false)`, the `OSJitterMonitor` background thread starts to measure operating system scheduling jitter independently.
 * **Affinity**: If an `acquireLock` supplier is configured in `JLBHOptions`, an attempt to acquire CPU affinity for the main benchmark thread might occur.
 
+[[resource-tracing]]
+The `JLBH` constructors check `jvm.resource.tracing` because intrusive resource tracing distorts benchmark measurements.
+Construction throws `IllegalStateException` when the property is empty or parses as `true` (case-insensitive).
+JLBH does not terminate the host JVM.
+Leave the property unset or set it to `false` when running a benchmark; other non-empty values follow `Boolean.parseBoolean` semantics.
+
 == 2. Warmup
 
 Before any measurements are formally recorded, the harness executes a warm-up phase:

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -129,6 +129,9 @@ A background thread measures scheduling gaps exceeding a configured threshold (`
 
 === 4.5 FN-005 CSV Serialisation
 Post-run, results can be persisted for offline analysis (`result.csv` by default).
+CSV files use UTF-8, preserving valid Unicode probe names on every platform.
+Readers must select UTF-8 rather than relying on their default charset.
+Malformed Unicode and write, flush or close failures are reported as `IOException`; the file may be incomplete on failure.
 
 === 4.6 FN-006 Event Loop Integration
 `eventLoopHandler(EventLoop)` allows benchmarks to operate inside Chronicle threading framework, avoiding extra threads.

--- a/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/JLBH.java
@@ -95,6 +95,8 @@ public class JLBH implements NanoSampler {
      * once {@link #start()} completes.
      *
      * @param jlbhOptions options controlling the benchmark execution
+     * @throws IllegalStateException if {@code jvm.resource.tracing} is empty or parses as
+     *                               {@code true}, or no benchmark task is configured
      */
     public JLBH(@NotNull JLBHOptions jlbhOptions) {
         this(jlbhOptions, System.out, null);
@@ -110,14 +112,16 @@ public class JLBH implements NanoSampler {
      * @param printStream    stream used for textual output, e.g. {@link System#out}
      * @param resultConsumer consumer that receives the {@link JLBHResult} once the benchmark has
      *                       finished; may be {@code null} if no programmatic result is required
+     * @throws IllegalStateException if {@code jvm.resource.tracing} is empty or parses as
+     *                               {@code true}, or no benchmark task is configured
      */
     public JLBH(@NotNull JLBHOptions jlbhOptions, @NotNull PrintStream printStream, Consumer<JLBHResult> resultConsumer) {
 
         final String resourceTracing = System.getProperty("jvm.resource.tracing");
 
         if (resourceTracing != null && (resourceTracing.isEmpty() || Boolean.parseBoolean(resourceTracing))) {
-            System.out.println("***** WARNING : JLBH can not be run if jvm.resource.tracing=" + resourceTracing + ", please remove all \"jvm.resource.tracing\" as this will corrupt your stats *****");
-            System.exit(-1);
+            throw new IllegalStateException("Cannot run JLBH with jvm.resource.tracing=" + resourceTracing
+                    + "; disable resource tracing to avoid distorting benchmark measurements");
         }
 
         this.jlbhOptions = jlbhOptions;

--- a/src/main/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializer.java
+++ b/src/main/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializer.java
@@ -8,8 +8,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -37,6 +39,10 @@ import java.util.Optional;
  * which will create a {@code result.csv} file in the working directory.  Other
  * overloads allow specifying the file name, the set of probes to export and
  * whether the OS jitter probe should be included.
+ * <p>
+ * Files use UTF-8, preserving Unicode probe names independently of the platform's
+ * default charset. Malformed Unicode and output failures are reported as
+ * {@link IOException}; output may be incomplete when an exception is thrown.
  */
 public class JLBHResultSerializer {
     public static final String THE_PROBE = "TheProbe";
@@ -98,7 +104,14 @@ public class JLBHResultSerializer {
      * @throws IOException if the file cannot be written
      */
     public static void runResultToCSV(JLBHResult jlbhResult, String fileName, Iterable<String> namesOfProbes, boolean includeOSJitter) throws IOException {
-        try (Writer pw = new BufferedWriter(new PrintWriter(Files.newOutputStream(Paths.get(fileName))))) {
+        writeResultsToCSV(jlbhResult, Files.newOutputStream(Paths.get(fileName)), namesOfProbes, includeOSJitter);
+    }
+
+    // Own both layers so the stream closes even when flushing the writer fails.
+    static void writeResultsToCSV(JLBHResult jlbhResult, OutputStream output,
+                                  Iterable<String> namesOfProbes, boolean includeOSJitter) throws IOException {
+        try (OutputStream stream = output;
+             Writer pw = new BufferedWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8.newEncoder()))) {
             writeHeader(pw);
 
             JLBHResult.ProbeResult probeResult = jlbhResult.endToEnd();
@@ -106,21 +119,21 @@ public class JLBHResultSerializer {
 
             for (String probeName : namesOfProbes) {
                 Optional<JLBHResult.ProbeResult> optProbe = jlbhResult.probe(probeName);
-                optProbe.ifPresent(probe -> writeProbeResult(pw, probeName, probe));
+                if (optProbe.isPresent())
+                    writeProbeResult(pw, probeName, optProbe.get());
             }
-            if (!includeOSJitter) return;
-            Optional<JLBHResult.ProbeResult> osJitterResult = jlbhResult.osJitter();
-            osJitterResult.ifPresent(osJitterRes -> writeProbeResult(pw, OS_JITTER, osJitterRes));
+            if (includeOSJitter) {
+                Optional<JLBHResult.ProbeResult> osJitterResult = jlbhResult.osJitter();
+                if (osJitterResult.isPresent())
+                    writeProbeResult(pw, OS_JITTER, osJitterResult.get());
+            }
+            pw.flush();
         }
     }
 
-    private static void writeProbeResult(Writer pw, String probeName, JLBHResult.ProbeResult probeResult) {
-        try {
-            JLBHResult.@NotNull RunResult runResult = probeResult.summaryOfLastRun();
-            writeRow(probeName, pw, runResult);
-        } catch (IOException e) {
-            throw new RuntimeException("Error writing probe results: " + probeName, e);
-        }
+    private static void writeProbeResult(Writer pw, String probeName, JLBHResult.ProbeResult probeResult) throws IOException {
+        JLBHResult.@NotNull RunResult runResult = probeResult.summaryOfLastRun();
+        writeRow(probeName, pw, runResult);
     }
 
     private static void writeRow(String probeName, Writer pw, JLBHResult.RunResult runResult) throws IOException {

--- a/src/test/java/net/openhft/chronicle/jlbh/JLBHConstructorTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/JLBHConstructorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.jlbh;
+
+import net.openhft.chronicle.core.Jvm;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
+class JLBHConstructorTest {
+    private static final String RESOURCE_TRACING = "jvm.resource.tracing";
+    private String originalResourceTracing;
+
+    @BeforeEach
+    void rememberProperty() {
+        originalResourceTracing = System.getProperty(RESOURCE_TRACING);
+        // Initialise Core before changing the property it also reads at startup.
+        Jvm.isResourceTracing();
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        setResourceTracing(originalResourceTracing);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"false", "true", "TRUE", "not-a-boolean"})
+    void shouldRejectIntrusiveTracingWithoutTerminatingTheHost(String value) throws Exception {
+        setResourceTracing(value);
+        JLBHOptions options = new JLBHOptions().jlbhTask(new JLBHTask() {
+            @Override
+            public void init(JLBH jlbh) {
+                fail("Construction must not start the task");
+            }
+
+            @Override
+            public void run(long startTimeNS) {
+                fail("Construction must not run the task");
+            }
+        });
+        try (PrintStream output = new PrintStream(new ByteArrayOutputStream(), false, "UTF-8")) {
+            for (Supplier<JLBH> constructor : Arrays.<Supplier<JLBH>>asList(
+                    () -> new JLBH(options), () -> new JLBH(options, output, null))) {
+                if (value != null && (value.isEmpty() || Boolean.parseBoolean(value))) {
+                    IllegalStateException failure = assertThrows(IllegalStateException.class, constructor::get);
+                    assertTrue(failure.getMessage().contains(RESOURCE_TRACING + "=" + value));
+                } else {
+                    assertNotNull(assertDoesNotThrow(constructor::get));
+                }
+            }
+        }
+    }
+
+    private static void setResourceTracing(String value) {
+        if (value == null)
+            System.clearProperty(RESOURCE_TRACING);
+        else
+            System.setProperty(RESOURCE_TRACING, value);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
+++ b/src/test/java/net/openhft/chronicle/jlbh/util/JLBHResultSerializerTest.java
@@ -6,15 +6,25 @@ package net.openhft.chronicle.jlbh.util;
 import net.openhft.chronicle.jlbh.JLBHResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.MalformedInputException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
+import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
 class JLBHResultSerializerTest {
@@ -39,7 +49,7 @@ class JLBHResultSerializerTest {
         Path out = subsetFile.toPath();
         JLBHResultSerializer.runResultToCSV(result, out.toString(), Collections.singletonList("TheProbe"), false);
 
-        List<String> lines = Files.readAllLines(out);
+        List<String> lines = Files.readAllLines(out, UTF_8);
         assertEquals(3, lines.size());
         assertEquals(",50th p-le,90th p-le,99th p-le,999th p-le,9999th p-le,Worst,", lines.get(0));
         assertEquals("endToEnd,100,200,300,400,,600,", lines.get(1));
@@ -60,7 +70,7 @@ class JLBHResultSerializerTest {
         Path out = fullFile.toPath();
         JLBHResultSerializer.runResultToCSV(result, out.toString(), Arrays.asList("Custom", "Missing"), true);
 
-        List<String> lines = Files.readAllLines(out);
+        List<String> lines = Files.readAllLines(out, UTF_8);
         assertEquals(4, lines.size());
         assertEquals("endToEnd,100,200,300,400,500,600,", lines.get(1));
         assertEquals("Custom,100,400,300,400,700,600,", lines.get(2));
@@ -76,9 +86,104 @@ class JLBHResultSerializerTest {
         Files.deleteIfExists(output);
         JLBHResultSerializer.runResultToCSV(result);
         assertTrue(Files.exists(output));
-        List<String> lines = Files.readAllLines(output);
+        List<String> lines = Files.readAllLines(output, UTF_8);
         assertEquals(4, lines.size());
         Files.deleteIfExists(output);
+    }
+
+    static Stream<Arguments> probeNames() {
+        return Stream.of(
+                Arguments.of("ASCII", "ASCII".getBytes(US_ASCII)),
+                Arguments.of("\u00e9", new byte[]{(byte) 0xc3, (byte) 0xa9}),
+                Arguments.of("\u20ac", new byte[]{(byte) 0xe2, (byte) 0x82, (byte) 0xac}),
+                Arguments.of("\ud83d\ude80", new byte[]{(byte) 0xf0, (byte) 0x9f, (byte) 0x9a, (byte) 0x80}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("probeNames")
+    void shouldWriteExactUtf8BytesAndRoundTripProbeNames(String suffix, byte[] encodedSuffix) throws IOException {
+        String name = "probe-" + suffix;
+        FakeResult result = resultWithProbe(name);
+        Path output = tmp.toPath().resolve("unicode.csv");
+
+        JLBHResultSerializer.runResultToCSV(result, output.toString(), Collections.singletonList(name), false);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        expected.write((",50th p-le,90th p-le,99th p-le,999th p-le,9999th p-le,Worst,\n"
+                + "endToEnd,100,200,300,400,,600,\nprobe-").getBytes(US_ASCII));
+        expected.write(encodedSuffix);
+        expected.write(",100,200,300,400,,600,\n".getBytes(US_ASCII));
+        assertArrayEquals(expected.toByteArray(), Files.readAllBytes(output));
+        assertEquals(name + ",100,200,300,400,,600,", Files.readAllLines(output, UTF_8).get(2));
+    }
+
+    @Test
+    void shouldRejectMalformedUnicodeRatherThanReplaceIt() {
+        String name = "probe-\ud800";
+        Path output = tmp.toPath().resolve("malformed.csv");
+
+        assertThrows(MalformedInputException.class, () -> JLBHResultSerializer.runResultToCSV(
+                resultWithProbe(name), output.toString(), Collections.singletonList(name), false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputFailure.class)
+    void shouldPropagateOutputFailuresAndCloseTheStream(OutputFailure failure) {
+        // A large name forces a write while a probe row is being emitted, before the final flush.
+        char[] characters = new char[32_768];
+        Arrays.fill(characters, 'p');
+        String name = new String(characters);
+        FailingOutputStream output = new FailingOutputStream(failure);
+
+        IOException error = assertThrows(IOException.class, () -> JLBHResultSerializer.writeResultsToCSV(
+                resultWithProbe(name), output, Collections.singletonList(name), false));
+
+        assertEquals("failure during " + failure, error.getMessage());
+        assertTrue(output.closed, "The destination must close even when writing or flushing fails");
+    }
+
+    private static FakeResult resultWithProbe(String name) {
+        FakeRunResult run = new FakeRunResult(P50, P90, P99, P999, null, WORST);
+        return new FakeResult(run, Collections.singletonMap(name, run), Optional.empty());
+    }
+
+    enum OutputFailure { WRITE, FLUSH, CLOSE }
+
+    private static final class FailingOutputStream extends OutputStream {
+        private final OutputFailure failure;
+        private boolean closed;
+
+        private FailingOutputStream(OutputFailure failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public void write(int value) throws IOException {
+            failOn(OutputFailure.WRITE);
+        }
+
+        @Override
+        public void write(byte[] bytes, int offset, int length) throws IOException {
+            failOn(OutputFailure.WRITE);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            failOn(OutputFailure.FLUSH);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!closed) {
+                closed = true;
+                failOn(OutputFailure.CLOSE);
+            }
+        }
+
+        private void failOn(OutputFailure operation) throws IOException {
+            if (operation == failure)
+                throw new IOException("failure during " + failure);
+        }
     }
 
     private static final class FakeResult implements JLBHResult {


### PR DESCRIPTION
JLBH construction currently terminates the host JVM when resource tracing is enabled, and CSV output can silently swallow storage failures through `PrintWriter`. Throw a catchable `IllegalStateException` from both constructor paths and write CSV with an explicit UTF-8 reporting encoder. Preserve valid Unicode probe names and propagate malformed input, write, flush and close failures as `IOException`, including failures while emitting a probe row.

CSV readers must decode UTF-8 explicitly. This preserves existing ASCII output and Unicode output on UTF-8-default systems; it deliberately removes platform-default encoding dependence. Failed output may be partial. Public signatures are preserved.

Update the existing lifecycle guide, constructor Javadocs and CSV requirement (FN-005) together. The lifecycle guide is the canonical property description. Add 14 regression cases covering property values/restoration through both constructors, exact bytes and round trips for ASCII/Latin-1/euro/supplementary Unicode names, malformed Unicode, and write/flush/close failures with destination closure.

Extracted from #176 onto develop `b201544e3bbb3e2bc8b55bc57f585d4f2b91be8a`, retaining current dependencies and JUnit Jupiter. The sampling-counter conversion, example edits, agent/TODO scaffolding, documentation migration and old quality profile are deferred; this patch makes no watchdog or sampling-performance claim.

Validation:

| Clean full `mvn verify` | Result |
| --- | --- |
| Java 8, 64-bit | 44 passed, no failures/errors/skips |
| Java 25, 64-bit | 44 passed, no failures/errors/skips |
| Java 21, 32-bit | 44 passed, no failures/errors/skips |

All 11 serializer cases also pass with Java 8's default charset set to ISO-8859-1. Separate actual-library JVM probes show that the baseline exits with code 255 for empty/true tracing, whereas the revised constructor rejects those settings and the host continues normally. The unchanged develop baseline passed its original 30 tests on Java 8.

Commands, with the appropriate `JAVA_HOME` and matching `PATH`:

```bash
mvn -o -nsu clean verify -Dsurefire.rerunFailingTestsCount=0 -l jlbh-verify.log
JAVA_TOOL_OPTIONS=-Dfile.encoding=ISO-8859-1 mvn -o -nsu test \
  -Dtest=JLBHResultSerializerTest -l serializer-latin1-default.log
mvn -o -nsu help:effective-pom -Doutput=effective-pom.xml
```

The inherited Checkstyle 3.3.0 plugin / Checkstyle 9.3 configuration and license/Javadoc checks pass. Checkstyle uses `google_checks.xml` and chronicle-quality-rules 1.23ea6, including test sources; its warning-level diagnostics remain subject to the existing parent failure threshold. This is not a warning-free style audit or validation of #176's separate quality profile.

Fresh platform CI is required before merge. The historical Linux failure on #176 (TeamCity build 1237958) remains unclassified because the log endpoint requires authentication; it is not evidence against this extraction or attributed to a particular old change.

Fresh CI on `c715fd95477e49e4dc748d552836b257c5877c0d`, checked on 11 September 2026: **one failed, 12 queued**. [Pull Requests Linux build 1353486](https://teamcity.chronicle.software/buildConfiguration/OpenHFT_Jlbh_PullRequestsLinux/1353486) failed; its log download returns HTTP 401, so its cause remains unclassified. Windows and Mac are still queued. Hold the merge until this failure is diagnosed and the required platform checks complete; the local matrix does not replace that evidence.


## Shared snapshot repository repair - 12 September 2026

[188](https://github.com/OpenHFT/JLBH/pull/188) owns the obsolete snapshot URL correction on `develop`. Both this PR's Pull Requests Linux build 1353486 and unchanged-develop build 1351468 fail resolving the same BOM from the old URL.

A disposable composition of this exact head with the one-line shared correction passes full Java 8 `clean verify`: 44 tests, zero failures/errors/skips/retries, from an initially empty isolated Maven repository and empty user settings. The shared repair alone passes all 30 baseline tests. This PR's branch is unchanged; incorporate the focused repair after it lands and complete normal CI/review.
