### PR TITLE
Use the current Maven snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <repository>
             <id>Snapshot Repository</id>
             <name>Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>


### PR DESCRIPTION
Clean JLBH builds cannot resolve `chronicle-bom:2026.0-SNAPSHOT` because the shared POM points at the obsolete OSSRH snapshot repository. Update the URL to the current Central snapshot endpoint. The dependency versions and repository policy stay the same.

This independently useful correction targets `develop` and is the shared prerequisite for #187. The original TeamCity failures are develop build [1351468](https://teamcity.chronicle.software/viewLog.html?buildId=1351468) and #187 build [1353486](https://teamcity.chronicle.software/viewLog.html?buildId=1353486), on the same agent and settings hash.

Validation on Linux amd64 / Java 8u502 / Maven 3.9.11, using separate initially empty Maven repositories and empty user settings:

- Unchanged develop reproduces the missing BOM/model failure before tests execute.
- Develop with this one-line correction passes full `clean verify`: 30 tests, no failures, errors, skips or retries.
- #187 composed with the same correction passes full `clean verify`: 44 tests, no failures, errors, skips or retries. This was a disposable control; #187's branch is unchanged.

The current BOM resolves as `2026.0-20260907.105301-92`. Logs, source patches and resolved test-classpath hashes are retained in the next-wave repair evidence pack. Supported-platform CI and review remain required; successful local resolution does not qualify TeamCity's effective settings by itself.

<!-- codex-next-wave-ci-20260912 -->
### Fresh CI evidence, 12 September 2026

TeamCity [Linux build 1356900](https://teamcity.chronicle.software/build/1356900) checked out this exact head and passed all 30 tests, with none ignored or muted and no first-attempt failure/rerun markers found in the full log. It used the same configuration and agent as the failing develop/#187 builds. Other platform contexts and review remain outstanding.
<!-- /codex-next-wave-ci-20260912 -->
